### PR TITLE
Selective cache purges in Cloudflare after deploying with GitHub Actions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -57,3 +57,10 @@ jobs:
           gitHubToken: ${{ secrets.GITHUB_TOKEN }}
           branch: main
           wranglerVersion: '3'
+
+      - name: Purge cache
+        uses: jakejarvis/cloudflare-purge-action@master
+        env:
+          CLOUDFLARE_ZONE: ${{ secrets.CLOUDFLARE_ZONE }}
+          CLOUDFLARE_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          PURGE_URLS: '["https://www.langx.io", "https://langx.io"]'


### PR DESCRIPTION
This pull request adds the ability to perform selective cache purges in Cloudflare after deploying with GitHub Actions. Instead of purging the entire cache, specific URLs or resources can now be specified for purging. This improves efficiency, reduces unnecessary cache invalidation, and ensures that only necessary resources are purged from the cache. The changes include adding a step in the GitHub Actions workflow that uses the `jakejarvis/cloudflare-purge-action` action to purge the specified URLs from the Cloudflare cache. Fixes #51.