### PR TITLE
Put Pro+ on the site

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,10 +11,15 @@ site. They are mirrored in [`src/lib/data/plans.ts`](src/lib/data/plans.ts) and
 [`src/lib/data/token.ts`](src/lib/data/token.ts), each of which points at the
 file in `langx2` it copies:
 
-| Here                    | Source of truth in `langx2`                                                  |
-| ----------------------- | ---------------------------------------------------------------------------- |
-| `src/lib/data/plans.ts` | `packages/shared/src/limits.ts` (`PLAN_LIMITS`)                              |
-| `src/lib/data/token.ts` | `packages/shared/src/token.ts` (`TOKEN_RULES`), `cosmetics.ts` (`COSMETICS`) |
+| Here                       | Source of truth in `langx2`                                                  |
+| -------------------------- | ---------------------------------------------------------------------------- |
+| `src/lib/data/plans.ts`    | `packages/shared/src/limits.ts` (`PLAN_LIMITS`)                              |
+| `src/lib/data/features.ts` | `packages/shared/src/limits.ts` — which plan unlocks each feature            |
+| `src/lib/data/token.ts`    | `packages/shared/src/token.ts` (`TOKEN_RULES`), `cosmetics.ts` (`COSMETICS`) |
+
+There are three plans — free, Pro and Pro+ — and Pro+ is Pro plus LangX Copilot
+and Nearby. Anything here that describes a paid feature has to name the plan
+that actually unlocks it.
 
 When a limit or a token rule changes in `langx2`, change it in the matching file
 here. Nothing checks this automatically, so a claim on the site can drift into

--- a/src/lib/components/atoms/Tag.svelte
+++ b/src/lib/components/atoms/Tag.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	export let color: 'primary' | 'secondary' | 'pro' = 'primary';
+	export let color: 'primary' | 'secondary' | 'pro' | 'pro-plus' = 'primary';
 </script>
 
 <div class="tag {color}">
@@ -30,6 +30,10 @@
 		&.pro {
 			background-color: rgba(var(--color--pro-rgb), 0.14);
 			color: var(--color--pro);
+		}
+		&.pro-plus {
+			background-color: rgba(var(--color--pro-plus-rgb), 0.14);
+			color: var(--color--pro-plus);
 		}
 	}
 </style>

--- a/src/lib/components/organisms/About.svelte
+++ b/src/lib/components/organisms/About.svelte
@@ -18,7 +18,8 @@
 		<p>
 			<strong>Free to use. Always.</strong> Reply to every message you get, with no limits, and
 			correct as many as you like. <a class="text" href="/pro">LangX Pro</a> adds filters, unlimited
-			translation, and the ability to start as many new conversations as you want.
+			translation, and the ability to start as many new conversations as you want; Pro+ adds LangX Copilot
+			and Nearby on top.
 		</p>
 		<p>
 			The app and the API are <strong>open source</strong>, and you can host your own.

--- a/src/lib/components/organisms/FAQ.svelte
+++ b/src/lib/components/organisms/FAQ.svelte
@@ -20,13 +20,13 @@
 			title: 'Is LangX free?',
 			content: `<strong>Free to use, always.</strong> You can reply to every message you receive with no limits, and write as many corrections as you like — neither is capped on any plan. On the free plan you can start <strong>5 new conversations</strong> and use <strong>20 translations</strong> per rolling 24 hours.
 			<br><br>
-			<a href="/pro" class="link">LangX Pro</a> is a paid subscription that removes those two limits and adds discovery filters, seeing who viewed your profile, and incognito browsing.`,
+			<a href="/pro" class="link">LangX Pro</a> is a paid subscription that removes those limits and adds discovery filters, seeing who viewed your profile, and incognito browsing. <a href="/pro" class="link">LangX Pro+</a> adds LangX Copilot and the Nearby sort on top of that.`,
 			isOpen: false
 		},
 		{
 			id: 3,
 			title: 'How does LangX pay for itself?',
-			content: `LangX Pro subscriptions. That is the whole model: no ads, no advertising identifiers, no third-party analytics SDK, and no selling anyone's data.
+			content: `LangX Pro and Pro+ subscriptions. That is the whole model: no ads, no advertising identifiers, no third-party analytics SDK, and no selling anyone's data.
 			<br><br>
 			Two things are deliberately <em>not</em> behind the paywall. Replying to messages is unlimited, because a language exchange where you cannot answer someone is not a language exchange. And writing corrections is unlimited on every plan — rate-limiting the free side would shrink what a paying user receives just as much as what a free user gives.
 			<br><br>
@@ -45,6 +45,8 @@
 				<li>Daily streaks, LangX Tokens, and weekly, monthly, yearly and all-time leaderboards.</li>
 				<li>Discovery filters by gender, country, age and level (Pro).</li>
 				<li>Who viewed your profile, and incognito browsing (Pro).</li>
+				<li>Nearby: discovery sorted by distance, if you switch location sharing on (Pro+).</li>
+				<li>LangX Copilot, private AI feedback as you practise (Pro+, not in the first release).</li>
 				<li>Download or delete everything we hold about you, from inside the app.</li>
 				<li>Night mode.</li>
 				<li>Open source under BSD-3, and self-hostable.</li>
@@ -65,7 +67,7 @@
 			title: 'What is LangX Copilot 🤖?',
 			content: `Private feedback while you practise with a real person. You open it inside a chat room and it comments on your own messages — only you can see those messages.
 			<br><br>
-			<strong>It is not in the first release of v2.</strong> It is planned for a later one, and when it arrives the free plan includes a few uses a day with Pro unlimited within fair use. We are naming the timing plainly because this feature has been described as "coming soon" for a long time.`,
+			<strong>It is not in the first release of v2.</strong> It is planned for a later one, and it is the feature <a href="/pro" class="link">LangX Pro+</a> exists for. We are naming the timing plainly because this feature has been described as "coming soon" for a long time.`,
 			isOpen: false
 		},
 		{

--- a/src/lib/components/organisms/Pricing.svelte
+++ b/src/lib/components/organisms/Pricing.svelte
@@ -4,11 +4,12 @@
 </script>
 
 <section id="pricing">
-	<div class="table" role="table" aria-label="Free and Pro compared">
+	<div class="table" role="table" aria-label="Free, Pro and Pro+ compared">
 		<div class="row head" role="row">
 			<span class="what" role="columnheader">&nbsp;</span>
 			<span class="free" role="columnheader">Free</span>
 			<span class="pro" role="columnheader">Pro</span>
+			<span class="pro-plus" role="columnheader">Pro+</span>
 		</div>
 
 		{#each planRows as row}
@@ -19,23 +20,28 @@
 				</span>
 				<span class="free" role="cell"><span class="label">Free</span>{row.free}</span>
 				<span class="pro" role="cell"><span class="label">Pro</span>{row.pro}</span>
+				<span class="pro-plus" role="cell"><span class="label">Pro+</span>{row.proPlus}</span>
 			</div>
 		{/each}
 	</div>
 
 	<div class="fine">
 		<p>
-			The free plan's two caps are counted over a <strong>rolling 24 hours</strong>, not a calendar
-			day — so the fifth conversation you started yesterday evening frees up this evening, not at
+			The free plan's caps are counted over a <strong>rolling 24 hours</strong>, not a calendar day
+			— so the fifth conversation you started yesterday evening frees up this evening, not at
 			midnight.
 		</p>
 		<p>
-			Pro is a subscription, monthly or yearly, with a free trial. Prices are shown in the app in
+			<strong>Pro+ is everything in Pro, plus LangX Copilot and Nearby.</strong> Copilot is not in the
+			first release, so the row says so.
+		</p>
+		<p>
+			Both are subscriptions, monthly or yearly, with a free trial. Prices are shown in the app in
 			your own currency, because they are set per region.
 		</p>
 		<p>
-			Tokens cannot buy Pro, and never will. If they could, farming tokens would become a substitute
-			for subscribing — and the subscription is what funds the app.
+			Tokens cannot buy Pro or Pro+, and never will. If they could, farming tokens would become a
+			substitute for subscribing — and the subscription is what funds the app.
 			<a href="/#token">More about LangX Token</a>.
 		</p>
 	</div>
@@ -66,7 +72,7 @@
 
 	.row {
 		display: grid;
-		grid-template-columns: minmax(0, 2.2fr) minmax(0, 1fr) minmax(0, 1fr);
+		grid-template-columns: minmax(0, 2.2fr) repeat(3, minmax(0, 1fr));
 		gap: var(--space-sm);
 		padding: var(--space-sm) var(--space-md);
 		border-bottom: 1px solid var(--color--border);
@@ -82,6 +88,10 @@
 
 			.pro {
 				color: var(--color--pro);
+			}
+
+			.pro-plus {
+				color: var(--color--pro-plus);
 			}
 		}
 	}
@@ -102,7 +112,8 @@
 	}
 
 	.free,
-	.pro {
+	.pro,
+	.pro-plus {
 		font-size: 0.95rem;
 	}
 
@@ -133,8 +144,10 @@
 		gap: var(--space-2xs);
 	}
 
-	// A three-column table cannot survive 375px. Below tablet each row becomes a
-	// small card with its own Free/Pro labels.
+	// A four-column table cannot survive 375px. Below tablet each row becomes a
+	// small card with its own Free/Pro/Pro+ labels. Checked at 768px with the
+	// third column added: the value cells still fit on one line there, so the
+	// breakpoint stays where it was.
 	@include for-phone-only {
 		.row {
 			grid-template-columns: 1fr;

--- a/src/lib/components/organisms/WelcomeBack.svelte
+++ b/src/lib/components/organisms/WelcomeBack.svelte
@@ -68,7 +68,7 @@
 		<p>
 			What does not change, and is worth saying in the same breath: <strong
 				>replying to every message you get is unlimited</strong
-			>, and so is writing corrections, on both plans. The free plan limits how many conversations
+			>, and so is writing corrections, on every plan. The free plan limits how many conversations
 			you can open, never how much you can talk.
 			<a href="/pro">The full comparison is here</a>.
 		</p>

--- a/src/lib/data/features.ts
+++ b/src/lib/data/features.ts
@@ -2,7 +2,9 @@ import type { Feature } from '$lib/utils/types';
 
 // Every claim here has to be true of the shipping app. The numbers come from
 // `langx2/packages/shared/src/limits.ts` (PLAN_LIMITS) — when a limit changes
-// there, this file is the second place to change.
+// there, this file is the second place to change. The tier on a `pro` /
+// `pro-plus` tag comes from there too — tagging a Pro+ feature as Pro sells a
+// subscriber something their plan does not include.
 //
 // NOTE: the screenshots in `static/images/features/` are still v1's UI.
 export default [
@@ -41,12 +43,18 @@ export default [
 		image: 'images/features/3.png',
 		tags: [{ label: 'Voice & Photos' }]
 	},
+	// Nearby shares this card because there is no screenshot of it — the images
+	// are still v1's UI, and v1 had no Nearby.
 	{
 		name: '⚙️ Fine Tune Your Connections',
 		description:
-			'Narrow discovery by gender, country, age and level to find the partners who actually fit how you want to practise.',
+			'Narrow discovery by gender, country, age and level to find the partners who actually fit how you want to practise. Pro+ adds Nearby, which sorts by distance if you switch location sharing on.',
 		image: 'images/features/7.png',
-		tags: [{ label: 'Filters' }, { label: 'LangX Pro', color: 'pro' }]
+		tags: [
+			{ label: 'Filters' },
+			{ label: 'LangX Pro', color: 'pro' },
+			{ label: 'Nearby: Pro+', color: 'pro-plus' }
+		]
 	},
 	{
 		name: '🔍 Profile Insights',
@@ -86,8 +94,12 @@ export default [
 	{
 		name: '🤖 LangX Copilot',
 		description:
-			'Private feedback while you practise with a real person — only you see it. Not in the first release; it lands in a later one.',
+			'Private feedback while you practise with a real person — only you see it. The feature Pro+ is for, and not in the first release.',
 		image: 'images/features/1.png',
-		tags: [{ label: 'AI' }, { label: 'Coming Soon', color: 'secondary' }]
+		tags: [
+			{ label: 'AI' },
+			{ label: 'LangX Pro+', color: 'pro-plus' },
+			{ label: 'Coming Soon', color: 'secondary' }
+		]
 	}
 ] as Feature[];

--- a/src/lib/data/plans.ts
+++ b/src/lib/data/plans.ts
@@ -1,15 +1,15 @@
 /**
  * Mirror of `PLAN_LIMITS` in `langx2/packages/shared/src/limits.ts`.
  *
- * Kept as data rather than prose so the numbers appear on the site exactly
- * once. When a limit changes in langx2, this file is the only place here that
- * has to change — see the sync note in README.md.
+ * Three plans. Pro+ is Pro plus two things — LangX Copilot and Nearby — which
+ * is why every `proPlus` value repeats `pro` until the last two rows.
  */
 
 export type PlanRow = {
 	label: string;
 	free: string;
 	pro: string;
+	proPlus: string;
 	/** Shown under the row. Use it where the *reason* is the interesting part. */
 	note?: string;
 };
@@ -19,30 +19,58 @@ export const planRows: PlanRow[] = [
 		label: 'Replying to messages you receive',
 		free: 'Unlimited',
 		pro: 'Unlimited',
+		proPlus: 'Unlimited',
 		note: 'The free plan limits how many conversations you can open, never how much you can talk.'
 	},
 	{
 		label: 'Writing corrections',
 		free: 'Unlimited',
 		pro: 'Unlimited',
-		note: 'Deliberately the same on both plans. Correcting someone is a favour to them — rate-limiting free users would shrink what a paying user receives just as much.'
+		proPlus: 'Unlimited',
+		note: 'Deliberately the same on all plans. Correcting someone is a favour to them — rate-limiting free users would shrink what a paying user receives just as much.'
 	},
-	{ label: 'Starting new conversations', free: '5 per 24 hours', pro: 'Unlimited' },
-	{ label: 'In-chat translation', free: '20 per 24 hours', pro: 'Unlimited' },
+	{
+		label: 'Starting new conversations',
+		free: '5 per 24 hours',
+		pro: 'Unlimited',
+		proPlus: 'Unlimited'
+	},
+	{ label: 'In-chat translation', free: '20 per 24 hours', pro: 'Unlimited', proPlus: 'Unlimited' },
 	{
 		label: 'Photos and voice messages',
 		free: '50 per 24 hours',
 		pro: 'Unlimited',
+		proPlus: 'Unlimited',
 		note: 'A ceiling on abuse, not a paywall — a normal conversation never reaches it.'
 	},
-	{ label: 'Filters: gender, country, age, level', free: '—', pro: 'Yes' },
-	{ label: 'Who viewed your profile', free: 'How many', pro: 'Who they are' },
-	{ label: 'Incognito browsing', free: '—', pro: 'Yes' },
+	{ label: 'Filters: gender, country, age, level', free: '—', pro: 'Yes', proPlus: 'Yes' },
+	{
+		label: 'Who viewed your profile',
+		free: 'How many',
+		pro: 'Who they are',
+		proPlus: 'Who they are'
+	},
+	{ label: 'Incognito browsing', free: '—', pro: 'Yes', proPlus: 'Yes' },
 	{
 		label: 'Profile photos',
 		free: '6',
 		pro: '6',
+		proPlus: '6',
 		note: 'Also the same on purpose. A gallery is how someone shows they are a real person; gating it would make free profiles look like throwaway accounts.'
+	},
+	{
+		label: 'LangX Copilot',
+		free: '—',
+		pro: '—',
+		proPlus: 'Coming soon',
+		note: 'Private AI feedback while you practise. Not in the first release — the row is here because it is what Pro+ will add.'
+	},
+	{
+		label: 'Nearby: sort people by distance',
+		free: '—',
+		pro: '—',
+		proPlus: 'Yes',
+		note: 'Only if you switch location sharing on.'
 	}
 ];
 

--- a/src/lib/data/token.ts
+++ b/src/lib/data/token.ts
@@ -47,7 +47,7 @@ export const tokenIsNot = [
 	'It cannot be sent to another user.',
 	'It cannot be withdrawn. It does not leave the app.',
 	'It is not on a blockchain. There is no chain, no contract, no wallet address.',
-	'It cannot unlock LangX Pro.'
+	'It cannot unlock a paid plan. Those are subscriptions; tokens buy none of them.'
 ];
 
 /** v1 balances are credited to earned tokens divided by this. */

--- a/src/lib/scss/_themes.scss
+++ b/src/lib/scss/_themes.scss
@@ -14,6 +14,9 @@
 	// Borrowed from the app's design tokens (langx2/apps/mobile/src/lib/theme.ts)
 	// so Pro and streak read as the same thing in both places.
 	@include define-color('pro', #7a5af8);
+	// Same hue, one step deeper, as in the app: Pro+ is more Pro, not a rival
+	// product, and an unrelated colour would read as two things to choose from.
+	@include define-color('pro-plus', #5b21b6);
 	@include define-color('streak', #f79009);
 	@include define-color('accent', #3b6cf6);
 
@@ -65,6 +68,8 @@
 	@include define-color('yellow', #ffd400);
 
 	@include define-color('pro', #9b83ff);
+	// On dark, "deeper" is illegible, so the step runs the other way.
+	@include define-color('pro-plus', #c0a9ff);
 	@include define-color('streak', #ffa93d);
 	@include define-color('accent', #7ba0ff);
 

--- a/src/lib/utils/types.ts
+++ b/src/lib/utils/types.ts
@@ -10,8 +10,11 @@ export type SparkleType = {
 
 export type TagType = {
 	label: string;
-	/** `pro` marks a LangX Pro feature and uses the app's own Pro purple. */
-	color?: 'primary' | 'secondary' | 'pro';
+	/**
+	 * `pro` and `pro-plus` mark a paid feature and use the app's own purples.
+	 * Tag the plan that actually unlocks it — Pro+ is the wider one.
+	 */
+	color?: 'primary' | 'secondary' | 'pro' | 'pro-plus';
 };
 
 export type SocialLink = {};

--- a/src/routes/pro/+layout.svelte
+++ b/src/routes/pro/+layout.svelte
@@ -8,7 +8,7 @@
 <Seo
 	title="LangX Pro"
 	path="/pro"
-	description="What LangX Pro adds, what stays free, and why corrections are unlimited on both plans."
+	description="What LangX Pro and Pro+ add, what stays free, and why corrections are unlimited on every plan."
 />
 
 <Waves />

--- a/src/routes/pro/+page.svelte
+++ b/src/routes/pro/+page.svelte
@@ -6,7 +6,7 @@
 <div class="container">
 	<PageHeader
 		title="LangX Pro"
-		lede="LangX is free to use, and stays that way. Pro removes the two limits the free plan has and adds the tools for finding the right people to practise with."
+		lede="LangX is free to use, and stays that way. Pro lifts the free plan's limits and adds the tools for finding the right people to practise with. Pro+ adds LangX Copilot and Nearby on top."
 	/>
 	<Pricing />
 </div>


### PR DESCRIPTION
The app sells three plans and the site described two. Pro+ is Pro plus LangX Copilot and Nearby, and neither appeared anywhere outside the Terms and the privacy policy — so the pricing table, the features and the FAQ were all selling a product one plan smaller than the one in the stores.

- `plans.ts` gets a third column, values taken from `PLAN_LIMITS` in `langx/packages/shared/src/limits.ts`. Copilot is listed first of the two Pro+ rows because it is the reason to buy the plan.
- Copilot's cell says "Coming soon": it has no code behind it yet, which is what the app's own paywall says on the same row.
- `Pricing.svelte` renders four columns and still collapses into stacked cards on phones. Checked at 768px with the third column added — the value cells fit on one line, so the breakpoint did not move.
- `features.ts`: the Copilot card is tagged Pro+, and Nearby is described on the discovery card rather than a card of its own, because there is no screenshot of it.
- FAQ, the `/pro` lede, and a `pro-plus` colour for `Tag` and both themes (the app's `#5b21b6`, one shade lighter on dark).
- Drive-by: the fine print said "the free plan's two caps" while the free plan has three (5 / 20 / 50 per rolling 24 hours).

A second commit clears the same drift out of the home page summary, the `/pro` meta description, a welcome-back line and the token list. The published v2 announcement post is left alone — it describes the product as it was when it was written — and so are the Terms, which are governed by `langx/docs/legal/promise-change.md`.

Cross-checked against `PLAN_LIMITS` on langx `main`: `pro_plus` is a strict superset of `pro` with `nearby` and `copilot` flipped on, and nothing else differs. The table matches what the server enforces.

`npm run check` and `npm run build` pass locally; prettier clean.

Blocked by #115 — the PR check fails on every pull request for an unrelated reason.

Pairs with `langx/docs` PR "Say which plan LangX Copilot is on".