### PR TITLE
Unbreak the website PR check

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,14 +18,15 @@ jobs:
 
     # Steps this job must take to complete
     steps:
-      # Reference the main branch. For more information visit https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idstepsuses
+      # Pinned to a release rather than @main: an action tracked from a branch
+      # changes our CI whenever upstream changes, without a commit here.
       - name: Checkout under $GITHUB_WORKSPACE
-        uses: actions/checkout@main
+        uses: actions/checkout@v4
 
       # Specify which version of Node this project is using. For more information visit.
       # https://docs.github.com/en/actions/guides/building-and-testing-nodejs#specifying-the-nodejs-version
       - name: Set up NodeJS
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v4
         with:
           node-version: 20
 
@@ -40,9 +41,3 @@ jobs:
           BASE_PATH: '/${{ github.event.repository.name }}'
         run: |
           npm run build
-
-      - name: Upload Artifacts
-        uses: actions/upload-pages-artifact@v2
-        with:
-          # this should match the `pages` option in your adapter-static options
-          path: 'build/'


### PR DESCRIPTION
Every pull request has been failing in three seconds, before a step runs: "This request has been automatically failed because it uses a deprecated version of `actions/upload-artifact: v3`."

The source is `upload-pages-artifact@v2`, which calls v3 underneath. Rather than bump it, the step is gone. It uploaded a GitHub Pages artifact that nothing consumes: the site deploys from `deploy.yml` to Cloudflare Pages, and that workflow runs its own build and its own `upload-artifact@v4`. The step was left over from a Pages deploy that no longer exists, so upgrading it would have kept a dead artifact alive at the cost of a second maintenance point.

Two versions came up with it: `setup-node@v1` (2019) and `checkout@main`, which tracked a branch — upstream changing meant our CI changing with no commit here.

Left alone deliberately: the `BASE_PATH` env, which `deploy.yml` also sets and which keeps the two builds identical, and the step list itself — adding lint or tests here is a separate argument.

This blocks #114, which is otherwise green.
