### PR TITLE
Move the workflows off actions that run on a forced Node

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,10 +12,10 @@ jobs:
       deployments: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v7
 
       - name: Install Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v7
         with:
           node-version: 20
           cache: npm
@@ -30,7 +30,7 @@ jobs:
           npm run build
 
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: website
           path: 'build/'
@@ -43,10 +43,15 @@ jobs:
       deployments: write
     steps:
       - name: Download Artifacts
-        uses: actions/download-artifact@v4.1.7
+        uses: actions/download-artifact@v8
         with:
           name: website
 
+      # `cloudflare/pages-action` is archived and its README points at
+      # `wrangler-action`. Left alone here on purpose: swapping it changes the
+      # command, the token scope and the branch handling of the deploy that
+      # publishes langx.io, and none of that can be tested anywhere but on
+      # main. It is a change of its own, not a version bump.
       - name: Publish to Cloudflare Pages
         uses: cloudflare/pages-action@v1
         with:
@@ -58,8 +63,13 @@ jobs:
           branch: main
           wranglerVersion: '3'
 
+      # Pinned to the last tag rather than @master. The repository is archived
+      # and has not moved since 2022, so the branch is not going to change
+      # under us — but a branch reference is how an unrelated upstream commit
+      # gets to run in our deploy, which is worth closing whether or not this
+      # particular one is asleep.
       - name: Purge cache
-        uses: jakejarvis/cloudflare-purge-action@master
+        uses: jakejarvis/cloudflare-purge-action@v0.3.0
         env:
           CLOUDFLARE_ZONE: ${{ secrets.CLOUDFLARE_ZONE }}
           CLOUDFLARE_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,12 +21,12 @@ jobs:
       # Pinned to a release rather than @main: an action tracked from a branch
       # changes our CI whenever upstream changes, without a commit here.
       - name: Checkout under $GITHUB_WORKSPACE
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       # Specify which version of Node this project is using. For more information visit.
       # https://docs.github.com/en/actions/guides/building-and-testing-nodejs#specifying-the-nodejs-version
       - name: Set up NodeJS
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: 20
 


### PR DESCRIPTION
Every deploy prints the same warning the PR check died of last night, one step earlier in its life:

> Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: `actions/checkout@v3`, `actions/setup-node@v3`, `actions/upload-artifact@v4`, `actions/download-artifact@v4.1.7`, `cloudflare/pages-action@v1`.

That is the shape of the failure we already had in #115 — a version that works right up to the day the platform declines to carry it.

- `checkout` v3 → v7, `setup-node` v3 → v7, `upload-artifact` v4 → v7, `download-artifact` v4.1.7 → v8. `test.yml`'s checkout and setup-node move to v7 as well; v4 targets Node 20 too, so leaving them would keep the warning alive on the check this repo just fixed.
- `jakejarvis/cloudflare-purge-action` was tracked from `@master` — the same branch reference #115 removed from the PR check — and is now pinned to `v0.3.0`, its last tag. The repository is archived and has not moved since 2022, so this closes the door rather than reacting to it moving.

Left alone on purpose, each with the reason in the file:

- **`cloudflare/pages-action@v1`** is archived and its README points at `wrangler-action`. Swapping it changes the command, the token scope and the branch handling of the deploy that publishes langx.io, and none of that can be tested anywhere but on `main`. It is a change of its own, not a version bump.
- **`node-version: 20`** is the project's Node, not the actions' runtime. The warning is about the latter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)