### PR TITLE
Make /pro three lists instead of a grid

### DIFF
--- a/src/lib/components/organisms/Pricing.svelte
+++ b/src/lib/components/organisms/Pricing.svelte
@@ -1,49 +1,33 @@
 <script lang="ts">
-	import { planRows } from '$lib/data/plans';
+	import { plans, planNotes } from '$lib/data/plans';
 	import AppStores from '$lib/components/molecules/AppStores.svelte';
 </script>
 
 <section id="pricing">
-	<div class="table" role="table" aria-label="Free, Pro and Pro+ compared">
-		<div class="row head" role="row">
-			<span class="what" role="columnheader">&nbsp;</span>
-			<span class="free" role="columnheader">Free</span>
-			<span class="pro" role="columnheader">Pro</span>
-			<span class="pro-plus" role="columnheader">Pro+</span>
-		</div>
-
-		{#each planRows as row}
-			<div class="row" role="row">
-				<span class="what" role="cell">
-					{row.label}
-					{#if row.note}<small>{row.note}</small>{/if}
-				</span>
-				<span class="free" role="cell"><span class="label">Free</span>{row.free}</span>
-				<span class="pro" role="cell"><span class="label">Pro</span>{row.pro}</span>
-				<span class="pro-plus" role="cell"><span class="label">Pro+</span>{row.proPlus}</span>
-			</div>
+	<div class="plans">
+		{#each plans as plan}
+			<article class="plan {plan.tone ?? ''}">
+				<h2>{plan.name}</h2>
+				<p class="tagline">{plan.tagline}</p>
+				<ul>
+					{#each plan.points as point}
+						<li>
+							<span class="label">
+								{point.label}
+								{#if point.pending}<em>Coming soon</em>{/if}
+							</span>
+							{#if point.note}<small>{point.note}</small>{/if}
+						</li>
+					{/each}
+				</ul>
+			</article>
 		{/each}
 	</div>
 
 	<div class="fine">
-		<p>
-			The free plan's caps are counted over a <strong>rolling 24 hours</strong>, not a calendar day
-			— so the fifth conversation you started yesterday evening frees up this evening, not at
-			midnight.
-		</p>
-		<p>
-			<strong>Pro+ is everything in Pro, plus LangX Copilot and Nearby.</strong> Copilot is not in the
-			first release, so the row says so.
-		</p>
-		<p>
-			Both are subscriptions, monthly or yearly, with a free trial. Prices are shown in the app in
-			your own currency, because they are set per region.
-		</p>
-		<p>
-			Tokens cannot buy Pro or Pro+, and never will. If they could, farming tokens would become a
-			substitute for subscribing — and the subscription is what funds the app.
-			<a href="/#token">More about LangX Token</a>.
-		</p>
+		{#each planNotes as note}
+			<p>{note}</p>
+		{/each}
 	</div>
 
 	<div class="cta">
@@ -63,78 +47,103 @@
 		gap: var(--space-xl);
 	}
 
-	.table {
+	.plans {
+		display: grid;
+		grid-template-columns: repeat(3, minmax(0, 1fr));
+		gap: var(--space-md);
+		align-items: start;
+	}
+
+	.plan {
 		border: 1px solid var(--color--border);
 		border-radius: var(--radius-lg);
 		background: var(--color--card-background);
-		overflow: hidden;
-	}
-
-	.row {
-		display: grid;
-		grid-template-columns: minmax(0, 2.2fr) repeat(3, minmax(0, 1fr));
-		gap: var(--space-sm);
-		padding: var(--space-sm) var(--space-md);
-		border-bottom: 1px solid var(--color--border);
-		align-items: baseline;
-
-		&:last-child {
-			border-bottom: 0;
-		}
-
-		&.head {
-			font-weight: 700;
-			background: rgba(var(--color--text-rgb), 0.03);
-
-			.pro {
-				color: var(--color--pro);
-			}
-
-			.pro-plus {
-				color: var(--color--pro-plus);
-			}
-		}
-	}
-
-	.what {
+		padding: var(--space-lg);
 		display: flex;
 		flex-direction: column;
-		gap: var(--space-3xs);
-		font-weight: 600;
+		gap: var(--space-2xs);
+		height: 100%;
 
-		small {
-			font-weight: 400;
-			font-size: 0.82rem;
-			color: var(--color--text-shade);
-			line-height: 1.45;
-			max-width: 62ch;
+		h2 {
+			font-size: 1.3rem;
+			margin: 0;
+		}
+
+		// Each paid plan carries the app's own tier colour, so the three cards
+		// read as one ladder rather than three unrelated products.
+		&.pro h2 {
+			color: var(--color--pro);
+		}
+
+		&.pro-plus h2 {
+			color: var(--color--pro-plus);
 		}
 	}
 
-	.free,
-	.pro,
-	.pro-plus {
+	.tagline {
+		margin: 0 0 var(--space-2xs);
+		color: var(--color--text-shade);
 		font-size: 0.95rem;
 	}
 
-	// Only shown once the table collapses into stacked cards on phones.
-	.label {
-		display: none;
-		font-weight: 700;
+	ul {
+		list-style: none;
+		margin: 0;
+		padding: 0;
+		display: flex;
+		flex-direction: column;
+		gap: var(--space-xs);
+	}
+
+	// Two columns: the tick, then everything about the point. A note sits under
+	// its own label rather than under the tick, which is what makes the list
+	// scannable down the left edge.
+	li {
+		display: grid;
+		grid-template-columns: auto minmax(0, 1fr);
+		column-gap: 0.55em;
+		row-gap: 2px;
+		font-size: 0.95rem;
+
+		&::before {
+			content: '✓';
+			color: var(--color--pro);
+			line-height: 1.5;
+		}
+	}
+
+	.label,
+	small {
+		grid-column: 2;
+	}
+
+	.label em {
+		font-style: normal;
+		font-size: 0.75rem;
+		font-weight: 600;
+		text-transform: uppercase;
+		letter-spacing: 0.04em;
 		color: var(--color--text-shade);
-		margin-right: var(--space-2xs);
+		margin-left: var(--space-3xs);
+		white-space: nowrap;
+	}
+
+	small {
+		color: var(--color--text-shade);
+		font-size: 0.82rem;
+		line-height: 1.45;
 	}
 
 	.fine {
 		display: flex;
 		flex-direction: column;
-		gap: var(--space-sm);
-		font-size: 0.95rem;
+		gap: var(--space-2xs);
+		font-size: 0.9rem;
 		color: var(--color--text-shade);
 		max-width: 70ch;
 
-		strong {
-			color: var(--color--text);
+		p {
+			margin: 0;
 		}
 	}
 
@@ -144,26 +153,11 @@
 		gap: var(--space-2xs);
 	}
 
-	// A four-column table cannot survive 375px. Below tablet each row becomes a
-	// small card with its own Free/Pro/Pro+ labels. Checked at 768px with the
-	// third column added: the value cells still fit on one line there, so the
-	// breakpoint stays where it was.
-	@include for-phone-only {
-		.row {
+	// Three cards side by side stop being readable before the phone breakpoint,
+	// so they stack a step earlier than the old table did.
+	@include for-tablet-portrait-down {
+		.plans {
 			grid-template-columns: 1fr;
-			gap: var(--space-3xs);
-
-			&.head {
-				display: none;
-			}
-		}
-
-		.what {
-			margin-bottom: var(--space-3xs);
-		}
-
-		.label {
-			display: inline;
 		}
 	}
 </style>

--- a/src/lib/data/plans.ts
+++ b/src/lib/data/plans.ts
@@ -1,78 +1,77 @@
 /**
  * Mirror of `PLAN_LIMITS` in `langx2/packages/shared/src/limits.ts`.
  *
- * Three plans. Pro+ is Pro plus two things — LangX Copilot and Nearby — which
- * is why every `proPlus` value repeats `pro` until the last two rows.
+ * Written as three lists rather than a grid on purpose. A comparison table
+ * makes a reader check eleven rows across three columns to answer the only
+ * question they have — what do I get if I pay — and most of those rows say the
+ * same thing three times, because Pro+ is a strict superset of Pro and both
+ * inherit everything free already has.
+ *
+ * So each list holds only what is *new* at that plan. When a limit changes in
+ * langx2, this file is the only place here that has to change.
  */
 
-export type PlanRow = {
+export type PlanPoint = {
 	label: string;
-	free: string;
-	pro: string;
-	proPlus: string;
-	/** Shown under the row. Use it where the *reason* is the interesting part. */
+	/** Shown under the label, small. Only where the reason is worth a line. */
 	note?: string;
+	/** Renders as "Coming soon" — for something sold before it is built. */
+	pending?: boolean;
 };
 
-export const planRows: PlanRow[] = [
+export type Plan = {
+	name: string;
+	tagline: string;
+	/** `pro` and `pro-plus` tint the card the way the app tints the tier. */
+	tone?: 'pro' | 'pro-plus';
+	points: PlanPoint[];
+};
+
+export const plans: Plan[] = [
 	{
-		label: 'Replying to messages you receive',
-		free: 'Unlimited',
-		pro: 'Unlimited',
-		proPlus: 'Unlimited',
-		note: 'The free plan limits how many conversations you can open, never how much you can talk.'
+		name: 'Free',
+		tagline: 'A real plan, not a trial.',
+		points: [
+			{ label: 'Unlimited replies to anyone who writes to you' },
+			{ label: 'Unlimited corrections' },
+			{ label: '5 new conversations a day' },
+			{ label: '20 translations a day' },
+			{ label: '6 photos on your profile' }
+		]
 	},
 	{
-		label: 'Writing corrections',
-		free: 'Unlimited',
-		pro: 'Unlimited',
-		proPlus: 'Unlimited',
-		note: 'Deliberately the same on all plans. Correcting someone is a favour to them — rate-limiting free users would shrink what a paying user receives just as much.'
+		name: 'Pro',
+		tagline: 'Everything in Free, without the limits.',
+		tone: 'pro',
+		points: [
+			{ label: 'Unlimited new conversations' },
+			{ label: 'Unlimited translation' },
+			{ label: 'Filters: gender, country, age, level' },
+			{ label: 'See who viewed your profile' },
+			{ label: 'Incognito browsing' }
+		]
 	},
 	{
-		label: 'Starting new conversations',
-		free: '5 per 24 hours',
-		pro: 'Unlimited',
-		proPlus: 'Unlimited'
-	},
-	{ label: 'In-chat translation', free: '20 per 24 hours', pro: 'Unlimited', proPlus: 'Unlimited' },
-	{
-		label: 'Photos and voice messages',
-		free: '50 per 24 hours',
-		pro: 'Unlimited',
-		proPlus: 'Unlimited',
-		note: 'A ceiling on abuse, not a paywall — a normal conversation never reaches it.'
-	},
-	{ label: 'Filters: gender, country, age, level', free: '—', pro: 'Yes', proPlus: 'Yes' },
-	{
-		label: 'Who viewed your profile',
-		free: 'How many',
-		pro: 'Who they are',
-		proPlus: 'Who they are'
-	},
-	{ label: 'Incognito browsing', free: '—', pro: 'Yes', proPlus: 'Yes' },
-	{
-		label: 'Profile photos',
-		free: '6',
-		pro: '6',
-		proPlus: '6',
-		note: 'Also the same on purpose. A gallery is how someone shows they are a real person; gating it would make free profiles look like throwaway accounts.'
-	},
-	{
-		label: 'LangX Copilot',
-		free: '—',
-		pro: '—',
-		proPlus: 'Coming soon',
-		note: 'Private AI feedback while you practise. Not in the first release — the row is here because it is what Pro+ will add.'
-	},
-	{
-		label: 'Nearby: sort people by distance',
-		free: '—',
-		pro: '—',
-		proPlus: 'Yes',
-		note: 'Only if you switch location sharing on.'
+		name: 'Pro+',
+		tagline: 'Everything in Pro, and the two features only it has.',
+		tone: 'pro-plus',
+		points: [
+			{
+				label: 'LangX Copilot',
+				note: 'Private AI feedback while you practise.',
+				pending: true
+			},
+			{
+				label: 'Nearby',
+				note: 'Sorts discovery by distance, if you turn location sharing on.'
+			}
+		]
 	}
 ];
 
-/** Limits that are counted over a rolling window, not a calendar day. */
-export const quotaWindow = 'rolling 24 hours';
+/** The three lines worth keeping under the plans. Everything else was noise. */
+export const planNotes = [
+	'The free plan’s daily caps run over a rolling 24 hours, not a calendar day.',
+	'Pro and Pro+ are monthly or yearly, with a free trial. Prices are set per region and shown in the app.',
+	'Tokens cannot buy a paid plan, and never will.'
+];

--- a/src/lib/data/plans.ts
+++ b/src/lib/data/plans.ts
@@ -36,6 +36,10 @@ export const plans: Plan[] = [
 			{ label: 'Unlimited corrections' },
 			{ label: '5 new conversations a day' },
 			{ label: '20 translations a day' },
+			{
+				label: '50 photos and voice messages a day',
+				note: 'A ceiling on abuse, not a paywall — a normal conversation never reaches it.'
+			},
 			{ label: '6 photos on your profile' }
 		]
 	},

--- a/src/routes/pro/+page.svelte
+++ b/src/routes/pro/+page.svelte
@@ -6,7 +6,7 @@
 <div class="container">
 	<PageHeader
 		title="LangX Pro"
-		lede="LangX is free to use, and stays that way. Pro lifts the free plan's limits and adds the tools for finding the right people to practise with. Pro+ adds LangX Copilot and Nearby on top."
+		lede="Free is a real plan. Pro removes its limits, and Pro+ adds the two features only it has."
 	/>
 	<Pricing />
 </div>


### PR DESCRIPTION
The comparison table asked a reader to check eleven rows across three columns to answer the one question they arrived with — *what do I get if I pay* — and most of those rows said the same thing three times over, because Pro+ is a strict superset of Pro and both inherit everything free already has. Six of the rows carried a paragraph of explanation underneath.

Each plan is now a card listing only what is **new** at that plan:

- **Free** — unlimited replies, unlimited corrections, 5 new conversations a day, 20 translations a day, 6 photos.
- **Pro** — unlimited new conversations, unlimited translation, filters, who viewed your profile, incognito.
- **Pro+** — two lines: LangX Copilot (marked `COMING SOON`, because it still has no code behind it) and Nearby.

The four fine-print paragraphs are three lines, and the page lede is one sentence. Card headings carry the app's own tier colours, so the three read as one ladder rather than three products to choose between.

Nothing about the plans themselves changed — the values still come from `PLAN_LIMITS` in `langx/packages/shared/src/limits.ts`, and `plans.ts` still exists only to mirror it.

Checked at 1280px and 390px; the cards stack a breakpoint earlier than the old table did, because three of them stop being readable before the phone width. `npm run check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)