### PR TITLE
Mirror the day-repair sink from the app

### DIFF
--- a/src/lib/data/token.ts
+++ b/src/lib/data/token.ts
@@ -33,6 +33,12 @@ export const tokenSinks = [
 		description: 'Rescues one missed day. You can bank two at a time.'
 	},
 	{
+		name: 'Fill in a missed day',
+		price: '300 tokens',
+		description:
+			'Fills one empty square on your activity map, within the last 14 days. Two a month, and never today — today is earned.'
+	},
+	{
 		name: 'Frames and titles',
 		price: '500 – 10,000 tokens',
 		description:


### PR DESCRIPTION
`tokenSinks` on the token page claims to be the full list of what a token buys, and the app has just gained a third thing: **filling in one empty square on the activity map** — 300 tokens, within the last 14 days, twice a month, and never today.

The list being complete is the entire reason it is on the site. `docs/token-messaging-brief.md` turns *"that is the complete list, and it is complete on purpose"* into a promise, so a sink shipping without its line here quietly breaks it.

Nothing checks that this file and `packages/shared/src/token.ts` agree — `REPO_MAP.md` records the pairing precisely because only a person can keep it.

Mirrors langx/langx#975, which adds the sink, the activity map and the confirmation that tells you what a repair will do before you buy it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)