### PR TITLE
Say that we keep a date of birth and where the country comes from

### DIFF
--- a/src/lib/components/organisms/PrivacyPolicy.svelte
+++ b/src/lib/components/organisms/PrivacyPolicy.svelte
@@ -16,10 +16,10 @@
 
 		- **Email address** — for sign-in, verification and password reset. Required.
 		- **Display name and username** — shown on your profile. Required.
-		- **Year of birth** — used for the 18+ requirement. Only your age, never the date, is shown to anyone else.
+		- **Date of birth** — used for the 18+ requirement, and so that we can wish you a happy birthday. Only your age is ever shown to anyone else; the date itself is visible to nobody but you.
 		- **Languages and levels** — the entire matching mechanism depends on these. Required.
 		- **Gender** — shown on your profile and used by the Pro gender filter. "Undisclosed" is a valid answer.
-		- **Country and city** — shown on your profile and used by the Pro country filter. Optional.
+		- **City** — shown on your profile. Optional.
 		- **Photos** — your avatar and gallery. Optional.
 		- **Interests** — shown on your profile, and shared interests nudge someone higher in your suggestions. Optional.
 		- **A short text about you** — optional.
@@ -43,6 +43,8 @@
 		2.3 Technical information
 
 		Our servers necessarily see your IP address in order to answer a request, apply rate limits and refuse abuse. We do not build a profile from it and it is not stored as part of your account.
+
+		One thing is derived from it: **your country**, as a two-letter code, when you create your profile. It is shown on your profile and used by the Pro country filter, which is only worth having if the country is not something anyone can simply type. The address itself is not kept — only the country it resolved to. If it is wrong, granting location permission in the app replaces it with the country your device reports; nothing else can change it.
 
 	3. Approximate Location, and Only If You Ask For It
 

--- a/src/lib/components/organisms/TermsAndConditions.svelte
+++ b/src/lib/components/organisms/TermsAndConditions.svelte
@@ -8,7 +8,7 @@
 
 	2. User Eligibility
 
-		You must be at least 18 years old to create an account and use the LangX app. By using the App, you represent and warrant that you are at least 18 years old. Your year of birth is collected when you create a profile and the age requirement is enforced at that point.
+		You must be at least 18 years old to create an account and use the LangX app. By using the App, you represent and warrant that you are at least 18 years old. Your date of birth is collected when you create a profile and the age requirement is enforced at that point. Only your age is shown to other people.
 
 	3. Account Registration and Security
 


### PR DESCRIPTION
Two claims on the live site stopped being true this week; the app changes are in langx/langx#982.

**Date of birth, not year.** The age gate is unchanged — it still counts whole years, so somebody who turns 18 in December is admitted in January — but the day and month are kept now, so that birthdays can exist ([langx#500](https://github.com/langx/langx/issues/500)). Only the age is ever shown to anybody else; the date is visible to nobody but its owner. Both the privacy policy and the Terms said "year of birth".

**The country is no longer typed.** It is derived from the connection's IP when the profile is created — a country filter anyone can set by hand is not a filter — and afterwards only a location fix from the device can change it. The address itself is not stored, only the two-letter code it resolved to.

That last point is why §2.3 needed a line: "we do not build a profile from your IP address" is still true, but leaving it alone while quietly deriving a stored country from it would have been misleading.

`prettier --check` clean on both files.