### PR TITLE
Rename the plans, and stop the site claiming what the app no longer does

### DIFF
--- a/src/lib/components/organisms/About.svelte
+++ b/src/lib/components/organisms/About.svelte
@@ -17,9 +17,10 @@
 		</p>
 		<p>
 			<strong>Free to use. Always.</strong> Reply to every message you get, with no limits, and
-			correct as many as you like. <a class="text" href="/pro">LangX Pro</a> adds filters, unlimited
-			translation, and the ability to start as many new conversations as you want; Pro+ adds LangX Copilot
-			and Nearby on top.
+			correct as many as you like. <a class="text" href="/pro">Fluent</a> adds filters, a wider translation
+			allowance, a second language to learn, and the ability to start as many new conversations as you
+			want; Polyglot adds five learning languages, seeing who viewed you, incognito browsing, Nearby
+			and LangX Copilot on top.
 		</p>
 		<p>
 			The app and the API are <strong>open source</strong>, and you can host your own.

--- a/src/lib/components/organisms/FAQ.svelte
+++ b/src/lib/components/organisms/FAQ.svelte
@@ -20,13 +20,13 @@
 			title: 'Is LangX free?',
 			content: `<strong>Free to use, always.</strong> You can reply to every message you receive with no limits, and write as many corrections as you like — neither is capped on any plan. On the free plan you can start <strong>5 new conversations</strong> and use <strong>20 translations</strong> per rolling 24 hours.
 			<br><br>
-			<a href="/pro" class="link">LangX Pro</a> is a paid subscription that removes those limits and adds discovery filters, seeing who viewed your profile, and incognito browsing. <a href="/pro" class="link">LangX Pro+</a> adds LangX Copilot and the Nearby sort on top of that.`,
+			<a href="/pro" class="link">Fluent</a> is a paid subscription that removes those limits, widens the translation allowance and lets you learn more languages at once. <a href="/pro" class="link">Polyglot</a> adds seeing who viewed your profile, incognito browsing, the Nearby sort and LangX Copilot on top of that.`,
 			isOpen: false
 		},
 		{
 			id: 3,
 			title: 'How does LangX pay for itself?',
-			content: `LangX Pro and Pro+ subscriptions. That is the whole model: no ads, no advertising identifiers, no third-party analytics SDK, and no selling anyone's data.
+			content: `Fluent and Polyglot subscriptions. That is the whole model: no ads, no advertising identifiers, no third-party analytics SDK, and no selling anyone's data.
 			<br><br>
 			Two things are deliberately <em>not</em> behind the paywall. Replying to messages is unlimited, because a language exchange where you cannot answer someone is not a language exchange. And writing corrections is unlimited on every plan — rate-limiting the free side would shrink what a paying user receives just as much as what a free user gives.
 			<br><br>
@@ -43,10 +43,10 @@
 				<li>Translation built into the chat, so you never leave the conversation.</li>
 				<li>Voice messages and photos.</li>
 				<li>Daily streaks, LangX Tokens, and weekly, monthly, yearly and all-time leaderboards.</li>
-				<li>Discovery filters by gender, country, age and level (Pro).</li>
-				<li>Who viewed your profile, and incognito browsing (Pro).</li>
-				<li>Nearby: discovery sorted by distance, if you switch location sharing on (Pro+).</li>
-				<li>LangX Copilot, private AI feedback as you practise (Pro+, not in the first release).</li>
+				<li>Discovery filters by country, age and level — free; gender and city on Fluent.</li>
+				<li>Who viewed your profile, and incognito browsing (Polyglot).</li>
+				<li>Nearby: discovery sorted by distance, if you switch location sharing on (Polyglot).</li>
+				<li>LangX Copilot, private AI feedback as you practise (Polyglot, not in the first release).</li>
 				<li>Download or delete everything we hold about you, from inside the app.</li>
 				<li>Night mode.</li>
 				<li>Open source under BSD-3, and self-hostable.</li>
@@ -67,7 +67,7 @@
 			title: 'What is LangX Copilot 🤖?',
 			content: `Private feedback while you practise with a real person. You open it inside a chat room and it comments on your own messages — only you can see those messages.
 			<br><br>
-			<strong>It is not in the first release of v2.</strong> It is planned for a later one, and it is the feature <a href="/pro" class="link">LangX Pro+</a> exists for. We are naming the timing plainly because this feature has been described as "coming soon" for a long time.`,
+			<strong>It is not in the first release of v2.</strong> It is planned for a later one, and it is the feature <a href="/pro" class="link">Polyglot</a> exists for. We are naming the timing plainly because this feature has been described as "coming soon" for a long time.`,
 			isOpen: false
 		},
 		{

--- a/src/lib/components/organisms/Footer.svelte
+++ b/src/lib/components/organisms/Footer.svelte
@@ -23,7 +23,7 @@
 								<a href="https://backlog.langx.io" target="_blank">Backlog</a>
 							</li>
 							<li>
-								<a href="/pro">LangX Pro</a>
+								<a href="/pro">Fluent &amp; Polyglot</a>
 							</li>
 							<li>
 								<a href="/welcome-back">Coming from v1?</a>

--- a/src/lib/components/organisms/PrivacyPolicy.svelte
+++ b/src/lib/components/organisms/PrivacyPolicy.svelte
@@ -37,7 +37,7 @@
 		- **Push notification token** — only if you grant notification permission.
 		- **Profile views** — who viewed your profile. Not recorded at all when the viewer is browsing incognito, and deleted automatically after 90 days.
 		- **Blocks and reports** — only if you block or report someone.
-		- **Purchase state** — whether you have an active LangX Pro or Pro+ subscription, which store it came from, and when it renews or expires. Only if you subscribe.
+		- **Purchase state** — whether you have an active Fluent or Polyglot subscription, which store it came from, and when it renews or expires. Only if you subscribe.
 		- **Approximate location** — only if you switch it on. Section 3 describes it in full, because it is new in version 2 and it is the part worth reading carefully.
 
 		2.3 Technical information
@@ -48,7 +48,7 @@
 
 	3. Approximate Location, and Only If You Ask For It
 
-		LangX Pro+ includes a "Nearby" sort that orders people by roughly how far away they are. It is the only feature that uses location anywhere in LangX, and this is exactly what it does.
+		Polyglot includes a "Nearby" sort that orders people by roughly how far away they are. It is the only feature that uses location anywhere in LangX, and this is exactly what it does.
 
 		- **It is off until you turn it on.** Nothing writes your location at sign-up, during onboarding, or in the background. The only two places that ask for it are the switch in Settings and the Nearby tab itself, and both run your device's own permission prompt first.
 		- **When-in-use only.** The app declares no background location permission on either platform, so it cannot read your position while you are not using it.

--- a/src/lib/components/organisms/TermsAndConditions.svelte
+++ b/src/lib/components/organisms/TermsAndConditions.svelte
@@ -25,7 +25,7 @@
 
 		You can block any other user and report them to us from inside the App. We review reports and may remove content, suspend token earning, or suspend or terminate an account under section 8.
 
-	5. Free Plan, LangX Pro and LangX Pro+
+	5. Free Plan, Fluent and Polyglot
 
 		LangX is free to use. On the free plan you may reply to every message you receive without limit, and write corrections without limit. The free plan limits three things:
 
@@ -35,7 +35,7 @@
 
 		These are counted over a **rolling 24 hours** from each individual use, not per calendar day and not reset at midnight.
 
-		LangX Pro is a paid subscription that removes all three limits and adds discovery filters, the identity of people who viewed your profile, and incognito browsing. LangX Pro+ includes everything in Pro and adds the Nearby sort, which orders people by approximate distance; Nearby only works if you switch location sharing on, it shows other users a rounded distance rather than a position, and our [privacy policy](/privacy-policy) describes exactly what is stored. Both plans are offered monthly and yearly, with a trial period, at prices that vary by region and are shown to you before you purchase.
+		Fluent is a paid subscription that lifts the first and third limits, raises the machine-translation allowance to 300 per rolling 24 hours, lets you learn two languages at once, and adds discovery filters. Polyglot includes everything in Fluent, raises translations to 1,000 per rolling 24 hours and learning languages to five, and adds the identity of people who viewed your profile, incognito browsing, and the Nearby sort, which orders people by approximate distance; Nearby only works if you switch location sharing on, it shows other users a rounded distance rather than a position, and our [privacy policy](/privacy-policy) describes exactly what is stored. Both plans are offered monthly and yearly, with a trial period, at prices that vary by region and are shown to you before you purchase.
 
 		Subscriptions are billed through Apple's App Store, Google Play, or our web payment provider, depending on where you subscribe. They renew automatically at the end of each period unless cancelled at least 24 hours before it ends. You cancel and request refunds through the same store you purchased from, under that store's terms; we cannot cancel or refund a store subscription on your behalf.
 
@@ -50,7 +50,7 @@
 		- It cannot be transferred to another user.
 		- It cannot be withdrawn or redeemed for money or any other thing of value.
 		- It is not recorded on a blockchain.
-		- It cannot be used to obtain LangX Pro or any part of it.
+		- It cannot be used to obtain Fluent, Polyglot or any part of either.
 
 		Token balances held in version 1 of LangX are credited to your version 2 account divided by 100, rounded down. A balance below 100 therefore converts to nothing. Any earlier description of LangX Token as a tradable or on-chain asset, including the litepaper, does not describe the product and is not being built.
 

--- a/src/lib/components/organisms/WelcomeBack.svelte
+++ b/src/lib/components/organisms/WelcomeBack.svelte
@@ -51,13 +51,13 @@
 	</article>
 
 	<article class="block warning">
-		<h2>Some things that were free are now Pro</h2>
+		<h2>Some things that were free are now paid</h2>
 		<p>
 			v1 said LangX was free with no in-app purchases. v2 has a paid tier, and three things you used
 			to get for free moved into it:
 		</p>
 		<ul>
-			<li>Filters by gender, country, age and level in discovery</li>
+			<li>Filtering discovery by gender and city — country, age and level stay free</li>
 			<li>Seeing <em>who</em> viewed your profile — the count stays free</li>
 			<li>Browsing without leaving a trace</li>
 		</ul>

--- a/src/lib/data/features.ts
+++ b/src/lib/data/features.ts
@@ -3,7 +3,7 @@ import type { Feature } from '$lib/utils/types';
 // Every claim here has to be true of the shipping app. The numbers come from
 // `langx2/packages/shared/src/limits.ts` (PLAN_LIMITS) — when a limit changes
 // there, this file is the second place to change. The tier on a `pro` /
-// `pro-plus` tag comes from there too — tagging a Pro+ feature as Pro sells a
+// `pro-plus` tag comes from there too — tagging a Polyglot feature as Fluent sells a
 // subscriber something their plan does not include.
 //
 // NOTE: the screenshots in `static/images/features/` are still v1's UI.
@@ -25,7 +25,7 @@ export default [
 	{
 		name: '🌐 Translation When You Are Stuck',
 		description:
-			'Built into the chat, so you never leave the conversation to look something up. 20 a day on the free plan, unlimited on Pro.',
+			'Built into the chat, so you never leave the conversation to look something up. 20 a day on the free plan, 300 on Fluent and 1000 on Polyglot.',
 		image: 'images/features/9.png',
 		tags: [{ label: 'Translation' }]
 	},
@@ -48,12 +48,12 @@ export default [
 	{
 		name: '⚙️ Fine Tune Your Connections',
 		description:
-			'Narrow discovery by gender, country, age and level to find the partners who actually fit how you want to practise. Pro+ adds Nearby, which sorts by distance if you switch location sharing on.',
+			'Narrow discovery by country, age and level for free. Fluent adds gender and city, and Polyglot adds Nearby, which sorts by distance if you switch location sharing on.',
 		image: 'images/features/7.png',
 		tags: [
 			{ label: 'Filters' },
-			{ label: 'LangX Pro', color: 'pro' },
-			{ label: 'Nearby: Pro+', color: 'pro-plus' }
+			{ label: 'Gender, city: Fluent', color: 'pro' },
+			{ label: 'Nearby: Polyglot', color: 'pro-plus' }
 		]
 	},
 	{
@@ -94,7 +94,7 @@ export default [
 	{
 		name: '🤖 LangX Copilot',
 		description:
-			'Private feedback while you practise with a real person — only you see it. The feature Pro+ is for, and not in the first release.',
+			'Private feedback while you practise with a real person — only you see it. The feature Polyglot is for, and not in the first release.',
 		image: 'images/features/1.png',
 		tags: [
 			{ label: 'AI' },

--- a/src/lib/data/plans.ts
+++ b/src/lib/data/plans.ts
@@ -1,14 +1,14 @@
 /**
- * Mirror of `PLAN_LIMITS` in `langx2/packages/shared/src/limits.ts`.
+ * Mirror of `PLAN_LIMITS` in `langx/packages/shared/src/limits.ts`.
  *
  * Written as three lists rather than a grid on purpose. A comparison table
  * makes a reader check eleven rows across three columns to answer the only
  * question they have — what do I get if I pay — and most of those rows say the
- * same thing three times, because Pro+ is a strict superset of Pro and both
+ * same thing three times, because Polyglot is a superset of Fluent and both
  * inherit everything free already has.
  *
  * So each list holds only what is *new* at that plan. When a limit changes in
- * langx2, this file is the only place here that has to change.
+ * langx, this file is the only place here that has to change.
  */
 
 export type PlanPoint = {
@@ -36,6 +36,8 @@ export const plans: Plan[] = [
 			{ label: 'Unlimited corrections' },
 			{ label: '5 new conversations a day' },
 			{ label: '20 translations a day' },
+			{ label: '1 language you are learning, 1 you speak natively' },
+			{ label: 'Filters: country, age and level' },
 			{
 				label: '50 photos and voice messages a day',
 				note: 'A ceiling on abuse, not a paywall — a normal conversation never reaches it.'
@@ -44,30 +46,36 @@ export const plans: Plan[] = [
 		]
 	},
 	{
-		name: 'Pro',
+		name: 'Fluent',
 		tagline: 'Everything in Free, without the limits.',
 		tone: 'pro',
 		points: [
 			{ label: 'Unlimited new conversations' },
-			{ label: 'Unlimited translation' },
-			{ label: 'Filters: gender, country, age, level' },
-			{ label: 'See who viewed your profile' },
-			{ label: 'Incognito browsing' }
+			{
+				label: '300 translations a day',
+				note: 'Far more than a conversation uses. Translation is the one feature with a real per-request cost, so it has a number rather than a promise.'
+			},
+			{ label: '2 languages you are learning, 2 you speak natively' },
+			{ label: 'Filters: gender and city' }
 		]
 	},
 	{
-		name: 'Pro+',
-		tagline: 'Everything in Pro, and the two features only it has.',
+		name: 'Polyglot',
+		tagline: 'Everything in Fluent, and what it cannot do.',
 		tone: 'pro-plus',
 		points: [
+			{ label: 'See who viewed your profile' },
+			{ label: 'Incognito browsing' },
+			{ label: '1000 translations a day' },
+			{ label: '5 languages you are learning, 5 you speak natively' },
+			{
+				label: 'Nearby',
+				note: 'Sorts discovery by distance, if you turn location sharing on.'
+			},
 			{
 				label: 'LangX Copilot',
 				note: 'Private AI feedback while you practise.',
 				pending: true
-			},
-			{
-				label: 'Nearby',
-				note: 'Sorts discovery by distance, if you turn location sharing on.'
 			}
 		]
 	}
@@ -76,6 +84,6 @@ export const plans: Plan[] = [
 /** The three lines worth keeping under the plans. Everything else was noise. */
 export const planNotes = [
 	'The free plan’s daily caps run over a rolling 24 hours, not a calendar day.',
-	'Pro and Pro+ are monthly or yearly, with a free trial. Prices are set per region and shown in the app.',
+	'Fluent and Polyglot are monthly or yearly, with a free trial. Prices are set per region and shown in the app.',
 	'Tokens cannot buy a paid plan, and never will.'
 ];

--- a/src/lib/data/token.ts
+++ b/src/lib/data/token.ts
@@ -1,8 +1,8 @@
 /**
  * Mirror of `TOKEN_RULES` and `COSMETICS` in
- * `langx2/packages/shared/src/token.ts` and `cosmetics.ts`.
+ * `langx/packages/shared/src/token.ts` and `cosmetics.ts`.
  *
- * langx2 marks these as "starting values only" — they are expected to move
+ * langx marks these as "starting values only" — they are expected to move
  * once there is real activity data, which is why the page that renders them
  * says so out loud.
  */
@@ -23,7 +23,10 @@ export const streakMilestones = [
 	{ day: 7, bonus: 50 },
 	{ day: 30, bonus: 250 },
 	{ day: 100, bonus: 1000 },
-	{ day: 365, bonus: 5000 }
+	{ day: 180, bonus: 1500 },
+	{ day: 365, bonus: 5000 },
+	{ day: 730, bonus: 12000 },
+	{ day: 1095, bonus: 25000 }
 ];
 
 export const tokenSinks = [
@@ -34,15 +37,15 @@ export const tokenSinks = [
 	},
 	{
 		name: 'Fill in a missed day',
-		price: '300 tokens',
+		price: '600 tokens',
 		description:
 			'Fills one empty square on your activity map, within the last 14 days. Two a month, and never today — today is earned.'
 	},
 	{
 		name: 'Frames and titles',
-		price: '500 – 10,000 tokens',
+		price: '1,000 – 100,000 tokens',
 		description:
-			'Cosmetic only: bronze, silver and gold frames, and the Learner, Tutor and Polyglot titles.'
+			'Cosmetic only: ten avatar frames from Slate to Midnight, and ten titles from Beginner to Legend.'
 	}
 ];
 

--- a/src/lib/scss/_themes.scss
+++ b/src/lib/scss/_themes.scss
@@ -14,7 +14,7 @@
 	// Borrowed from the app's design tokens (langx2/apps/mobile/src/lib/theme.ts)
 	// so Pro and streak read as the same thing in both places.
 	@include define-color('pro', #7a5af8);
-	// Same hue, one step deeper, as in the app: Pro+ is more Pro, not a rival
+	// Same hue, one step deeper, as in the app: Polyglot is more Fluent, not a rival
 	// product, and an unrelated colour would read as two things to choose from.
 	@include define-color('pro-plus', #5b21b6);
 	@include define-color('streak', #f79009);

--- a/src/lib/utils/types.ts
+++ b/src/lib/utils/types.ts
@@ -12,7 +12,7 @@ export type TagType = {
 	label: string;
 	/**
 	 * `pro` and `pro-plus` mark a paid feature and use the app's own purples.
-	 * Tag the plan that actually unlocks it — Pro+ is the wider one.
+	 * Tag the plan that actually unlocks it — Polyglot is the wider one.
 	 */
 	color?: 'primary' | 'secondary' | 'pro' | 'pro-plus';
 };

--- a/src/routes/(blog-article)/langx-v2-what-changes-and-why/+page.md
+++ b/src/routes/(blog-article)/langx-v2-what-changes-and-why/+page.md
@@ -42,10 +42,11 @@ all-time leaderboards.
 
 ## The first broken promise: LangX is no longer free of charge
 
-v1 said LangX was free with no in-app purchases. v2 introduces **LangX Pro**, a
-paid subscription, and three things that used to be free are part of it:
+v1 said LangX was free with no in-app purchases. v2 introduces two paid
+subscriptions, **Fluent** and **Polyglot**, and three things that used to be
+free are part of them:
 
-- Filters by gender, country, age and level in discovery
+- Filtering discovery by gender and city — country, age and level stay free
 - Seeing **who** viewed your profile — the count stays free
 - Browsing without leaving a trace
 
@@ -54,7 +55,7 @@ start** and **20 translations**, each per rolling 24 hours.
 
 <Callout type="info">
 Replying to every message you receive is unlimited, and so is writing
-corrections, on both plans. The free plan limits how many conversations you can
+corrections, on every plan. The free plan limits how many conversations you can
 <em>open</em>, never how much you can talk.
 </Callout>
 
@@ -68,7 +69,7 @@ revenue. We would rather charge for filters than sell your attention: there are
 no ads, no advertising identifiers, and no third-party analytics SDK. The code
 stays open source under BSD-3, and you can host your own instance.
 
-The full comparison is on the [LangX Pro page](/pro).
+The full comparison is on the [plans page](/pro).
 
 ## The second: LangX Token is not what the litepaper described
 

--- a/src/routes/pro/+layout.svelte
+++ b/src/routes/pro/+layout.svelte
@@ -6,9 +6,9 @@
 </script>
 
 <Seo
-	title="LangX Pro"
+	title="LangX plans"
 	path="/pro"
-	description="What LangX Pro and Pro+ add, what stays free, and why corrections are unlimited on every plan."
+	description="What Fluent and Polyglot add, what stays free, and why corrections are unlimited on every plan."
 />
 
 <Waves />

--- a/src/routes/pro/+page.svelte
+++ b/src/routes/pro/+page.svelte
@@ -5,8 +5,8 @@
 
 <div class="container">
 	<PageHeader
-		title="LangX Pro"
-		lede="Free is a real plan. Pro removes its limits, and Pro+ adds the two features only it has."
+		title="LangX plans"
+		lede="Free is a real plan. Fluent lifts its limits, and Polyglot adds the features only it has."
 	/>
 	<Pricing />
 </div>

--- a/src/routes/welcome-back/+layout.svelte
+++ b/src/routes/welcome-back/+layout.svelte
@@ -8,7 +8,7 @@
 <Seo
 	title="Welcome back"
 	path="/welcome-back"
-	description="What changes for LangX v1 users: your username, your token balance, your streak, and what moved behind LangX Pro."
+	description="What changes for LangX v1 users: your username, your token balance, your streak, and what moved behind a paid plan."
 />
 
 <Waves />


### PR DESCRIPTION
`packages/shared/src/limits.ts` moved underneath this file. Pro and Pro+ are
now Fluent and Polyglot, translation is a number on every tier rather than a
promise, both language lists are tiered 1/2/5, and seeing who viewed you and
incognito browsing moved up to Polyglot. Nothing checks that this copy still
matches the app, so it drifts silently — REPO_MAP lists it for that reason.

Three claims here were already false before the rename and are corrected in
passing: discovery filters by country, age and level have been free since the
tier table gave them back, so the feature card, the FAQ and the welcome-back
page were all selling something the free plan already has. Only gender and
city are paid.

The v2 announcement post keeps its argument and its date; only the plan names
and that same filter list change, because a reader following its link to /pro
now lands on two differently-named plans.

## Mirrors
`REPO_MAP.md` lists `src/lib/data/plans.ts`, `features.ts` and `token.ts` as hand-kept copies of `langx/packages/shared`. This is the plan-limit half of that sync, following the tier rework in langx#1028.

🤖 Generated with [Claude Code](https://claude.com/claude-code)