### PR TITLE
Say that the email address outlives the deleted account

### DIFF
--- a/src/lib/components/organisms/DataDeletion.svelte
+++ b/src/lib/components/organisms/DataDeletion.svelte
@@ -1,6 +1,6 @@
 <section id="policy">
 
-	*Effective Date: 27, Aug 2026*
+	*Effective Date: 31, Aug 2026*
 
 	If you would like to delete your LangX account or the data we hold about you, you can do it yourself from inside the app — you do not need to contact us first.
 
@@ -12,12 +12,13 @@
 
 		The data is permanently removed **30 days** after you confirm. If you change your mind, signing back in during those 30 days cancels the deletion.
 
-		When the 30 days are up, your profile, photos, location, devices, blocks, the reports you filed, the record of profiles you viewed, your subscription record and your sign-in credentials are all deleted. Your photos, and the photos and voice messages you sent in chat, are deleted from storage as well as from the database, so nothing remains reachable by URL.
+		When the 30 days are up, your profile, photos, location, devices, blocks, the reports you filed, the record of profiles you viewed, your subscription record and your sign-in credentials are all deleted — with the single exception of your email address, which is kept on its own; see section 2. Your photos, and the photos and voice messages you sent in chat, are deleted from storage as well as from the database, so nothing remains reachable by URL.
 
-	2. Two things that are not deleted, and why
+	2. Three things that are not deleted, and why
 
 		- **Messages you sent stay in the other person's conversation**, with their content and attachments removed and marked as belonging to a deleted account. Removing them outright would rewrite a conversation someone else is also a party to.
 		- **The token ledger is kept as an audit record**, with your identity replaced by a random value stored nowhere else. The totals still reconcile and the rows no longer identify anyone. Your leaderboard entries are deleted outright.
+		- **Your email address is kept**, and nothing else with it. The account that held it is deleted in full; the address is moved to a list that contains no name, no profile and no identifier that could lead back to you, so that we can write to you about LangX in the future. We only send promotional email to an address whose owner turned promotional email on while their account existed. Email us at [hi@langx.io](mailto:hi@langx.io) with the subject "Data Deletion Request" and we will remove your address from that list as well.
 
 	3. Downloading your data first
 

--- a/src/lib/components/organisms/PrivacyPolicy.svelte
+++ b/src/lib/components/organisms/PrivacyPolicy.svelte
@@ -1,6 +1,6 @@
 <section id="policy">
 
-	*Effective Date: 27, Aug 2026*
+	*Effective Date: 31, Aug 2026*
 
 	1. Introduction
 
@@ -133,7 +133,7 @@
 
 		10.5 Notifications and email
 
-		You can turn off push notifications from your device settings, and opt out of marketing email using the link in any such email.
+		You can turn off push notifications from your device settings, and opt out of marketing email using the link in any such email. If you have already deleted your account, write to [hi@langx.io](mailto:hi@langx.io) and we will remove your address from the list described in section 11.
 
 	11. Data Retention and Deletion
 
@@ -141,10 +141,11 @@
 
 		When you delete your account it becomes invisible immediately and every session is ended. The data is permanently removed 30 days later; signing back in within those 30 days cancels the deletion. Your photos and voice messages are removed from storage as well as from the database, so nothing stays reachable by URL.
 
-		Two exceptions are worth stating plainly:
+		Three exceptions are worth stating plainly:
 
 		- **The token ledger survives as an audit record**, with your identity replaced by a random value that is stored nowhere else. The totals still reconcile and the rows no longer identify anyone. Your leaderboard entries are deleted outright.
 		- **Messages you sent are not deleted from the other person's conversation.** Their content is removed and they are marked as belonging to a deleted account. Deleting them outright would rewrite a conversation someone else is also a party to.
+		- **Your email address is kept**, and it is the only thing that is. When your account is removed we move the address onto a list that holds nothing else: no name, no profile, no identifier that links it back to the account, which is deleted in full. We keep it so that we can tell you about LangX in the future, and we only send promotional email to an address whose owner turned promotional email on while their account existed. Write to [hi@langx.io](mailto:hi@langx.io) at any time — before or after deleting your account — and we will remove your address from that list too.
 
 		Records of who viewed a profile are deleted automatically after 90 days, whether or not you delete your account.
 

--- a/src/lib/components/organisms/TermsAndConditions.svelte
+++ b/src/lib/components/organisms/TermsAndConditions.svelte
@@ -1,6 +1,6 @@
 <section id="policy">
 
-	*Effective Date: 27, Aug 2026*
+	*Effective Date: 31, Aug 2026*
 
 	1. Acceptance of Terms
 
@@ -65,6 +65,8 @@
 		You may delete your account from within the App at any time. On deletion your account becomes invisible immediately and every session is ended; the data is permanently removed 30 days later. Signing back in within those 30 days cancels the deletion.
 
 		Messages you sent are not removed from the other person's copy of the conversation. Their content is removed and they are marked as belonging to a deleted account, because deleting them outright would rewrite a conversation someone else is also a party to. The token ledger is kept as an anonymised audit record. Both exceptions are described in the [privacy policy](/privacy-policy).
+
+		Your email address is kept after the rest of your account is removed, on its own — no name, no profile, nothing that links it back to the account that has gone — so that we can write to you about LangX in the future. We only send promotional email to an address whose owner opted in to it, and you can have your address removed at any time by writing to [hi@langx.io](mailto:hi@langx.io). This is described in the [privacy policy](/privacy-policy) as well.
 
 		Deleting your account does not cancel a subscription bought through a store. Cancel it with Apple, Google or our web payment provider, whichever you bought it from, or it continues to renew.
 


### PR DESCRIPTION
The API side of this is not merged yet — **merge that first, or this page describes something the server does not do.** The change is prepared but parked: another session holds the `langx/langx` checkout, so the patch is sitting at `/root/langx-pending/marketing-email/` on the droplet rather than on a branch.

## What changes

The purge keeps exactly one thing now: the address the account signed up with, moved to a collection that holds nothing else — no name, no profile, no identifier that leads back to the account, which is still deleted in full including the Better Auth `user` row the address lived on.

Three pages said otherwise, so all three move:

- **Data deletion** — listed "sign-in credentials" among what is deleted, which is the page the stores read. Now names the exception in section 1 and explains it in section 2, which counts three things rather than two.
- **Privacy policy** — third bullet in section 11, plus a line in 10.5 for people who have already deleted their account and have no settings screen left.
- **Terms** — a paragraph in section 8.

Consent travels with the address and the wording follows it: promotional email only goes to an address whose owner turned promotions on while their account existed. `DEFAULT_NOTIFICATION_PREFS` starts that switch off because consent has to be given rather than withdrawn, and deleting an account is not the moment somebody starts giving it. Every page names hi@langx.io as the way to have the address dropped too.

Effective date moves to 31 August 2026 — what `CURRENT_TERMS_VERSION` has said since consent started being recorded at sign-up this morning.

## Checked

`vite build` prerenders all three pages and the new markdown renders as intended (the `postbuild` image step fails on this machine for an unrelated Node/`esm` reason). Prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)