### PR TITLE
Add the pronunciation award to the earning table

### DIFF
--- a/src/lib/data/token.ts
+++ b/src/lib/data/token.ts
@@ -10,6 +10,7 @@
 export const tokenEarning = [
 	{ action: 'Send a message', amount: '2' },
 	{ action: "Correct someone else's sentence", amount: '10' },
+	{ action: 'Answer a pronunciation request with a recording', amount: '10' },
 	{ action: 'First conversation where both of you have spoken', amount: '15' }
 ];
 


### PR DESCRIPTION
`src/lib/data/token.ts` is a hand-kept mirror of `TOKEN_RULES`, and nothing checks it — so it was quietly incomplete the moment [langx/langx#1038](https://github.com/langx/langx/pull/1038) shipped.

Answering a pronunciation request with a recording pays 10, the same as a correction. One row in `tokenEarning`; `Token.svelte` is data-driven, so no markup changes.

Caps, sinks, milestones and the pool are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)