### PR TITLE
Subscribe through v2's API, which is taking over api.langx.io

### DIFF
--- a/src/lib/components/molecules/NewsletterForm.svelte
+++ b/src/lib/components/molecules/NewsletterForm.svelte
@@ -13,7 +13,7 @@
 	async function handleSubmit(event: any) {
 		event.preventDefault();
 		sending = true;
-		const response = await fetch('https://api.langx.io/api/mail', {
+		const response = await fetch('https://api.langx.io/public/newsletter', {
 			method: 'POST',
 			headers: {
 				'Content-Type': 'application/json'


### PR DESCRIPTION
**Hold until `api.langx.io` points at v2.** Until then this form posts to a
path v1's Express does not have.

v1 put the address on a SendGrid list at `/api/mail`. The replacement lives
in `langx/langx` as `POST /public/newsletter` (Resend audience) and answers
with the same `status: 'ok'`, so nothing else on the form changes.

One of the three callers named in the runbook's "Retiring the v1 API".

🤖 Generated with [Claude Code](https://claude.com/claude-code)