### PR TITLE
Terms and Privacy: minimum age is 16, not 18

### DIFF
--- a/src/lib/components/organisms/PrivacyPolicy.svelte
+++ b/src/lib/components/organisms/PrivacyPolicy.svelte
@@ -1,6 +1,6 @@
 <section id="policy">
 
-	*Effective Date: 31, Aug 2026*
+	*Effective Date: 3, Sep 2026*
 
 	1. Introduction
 
@@ -16,7 +16,7 @@
 
 		- **Email address** — for sign-in, verification and password reset. Required.
 		- **Display name and username** — shown on your profile. Required.
-		- **Date of birth** — used for the 18+ requirement, and so that we can wish you a happy birthday. Only your age is ever shown to anyone else; the date itself is visible to nobody but you.
+		- **Date of birth** — used for the 16+ requirement, and so that we can wish you a happy birthday. Only your age is ever shown to anyone else; the date itself is visible to nobody but you.
 		- **Languages and levels** — the entire matching mechanism depends on these. Required.
 		- **Gender** — shown on your profile and used by the Pro gender filter. "Undisclosed" is a valid answer.
 		- **City** — shown on your profile. Optional.
@@ -157,7 +157,7 @@
 
 	12. Age
 
-		LangX is an 18+ service. You must be at least 18 to create an account, and this is enforced when your profile is created. The app is not directed to children, we do not knowingly collect information from anyone under 18, and we do not operate it under any "designed for families" programme. If we learn that an account belongs to someone under 18, we remove it.
+		LangX is a 16+ service. You must be at least 16 to create an account, and this is enforced when your profile is created. The app is not directed to children, we do not knowingly collect information from anyone under 16, and we do not operate it under any "designed for families" programme. If we learn that an account belongs to someone under 16, we remove it.
 
 	13. Changes to This Privacy Policy
 

--- a/src/lib/components/organisms/TermsAndConditions.svelte
+++ b/src/lib/components/organisms/TermsAndConditions.svelte
@@ -1,6 +1,6 @@
 <section id="policy">
 
-	*Effective Date: 31, Aug 2026*
+	*Effective Date: 3, Sep 2026*
 
 	1. Acceptance of Terms
 
@@ -8,7 +8,7 @@
 
 	2. User Eligibility
 
-		You must be at least 18 years old to create an account and use the LangX app. By using the App, you represent and warrant that you are at least 18 years old. Your date of birth is collected when you create a profile and the age requirement is enforced at that point. Only your age is shown to other people.
+		You must be at least 16 years old to create an account and use the LangX app. By using the App, you represent and warrant that you are at least 16 years old. Your date of birth is collected when you create a profile and the age requirement is enforced at that point. Only your age is shown to other people.
 
 	3. Account Registration and Security
 


### PR DESCRIPTION
Companion to langx/langx#1109, which lowers the enforced minimum age from 18 to 16.

- Terms §2 (User Eligibility): 18 → 16.
- Privacy: the date-of-birth bullet and §12 (Age): 18 → 16. "Not directed to children" and the no-Families sentence stay, both still true.
- Effective date on both: 3 Sep 2026.

Verified with `npm run check` (0 errors) and `npm run build`; the prerendered `terms-conditions.html` and `privacy-policy.html` carry the new text. The `postbuild` image step crashes locally under Node 22 (`esm` package), unrelated to this change.

Merge after #1109 so the published Terms never promise a lower age than the server enforces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
