### PR TITLE
Video in the copy, and say what the attachment limit counts

### DIFF
--- a/src/lib/components/organisms/DataDeletion.svelte
+++ b/src/lib/components/organisms/DataDeletion.svelte
@@ -12,7 +12,7 @@
 
 		The data is permanently removed **30 days** after you confirm. If you change your mind, signing back in during those 30 days cancels the deletion.
 
-		When the 30 days are up, your profile, photos, location, devices, blocks, the reports you filed, the record of profiles you viewed, your subscription record and your sign-in credentials are all deleted — with the single exception of your email address, which is kept on its own; see section 2. Your photos, and the photos and voice messages you sent in chat, are deleted from storage as well as from the database, so nothing remains reachable by URL.
+		When the 30 days are up, your profile, photos, location, devices, blocks, the reports you filed, the record of profiles you viewed, your subscription record and your sign-in credentials are all deleted — with the single exception of your email address, which is kept on its own; see section 2. Your photos, and the photos, videos and voice messages you sent in chat, are deleted from storage as well as from the database, so nothing remains reachable by URL.
 
 	2. Three things that are not deleted, and why
 

--- a/src/lib/components/organisms/PrivacyPolicy.svelte
+++ b/src/lib/components/organisms/PrivacyPolicy.svelte
@@ -28,7 +28,7 @@
 
 		2.2 Information created by using the app
 
-		- **Messages** — text, photos and voice messages, stored so we can deliver your conversations.
+		- **Messages** — text, photos, videos and voice messages, stored so we can deliver your conversations.
 		- **Text you ask us to translate** — sent to our translation provider, and the result kept for 30 days under a one-way hash of the original text so the same phrase is not paid for twice. That cache records the translation, not who asked for it.
 		- **Timezone** — so that your streak day and any reminders follow your local day rather than ours. Optional; we fall back to UTC.
 		- **Approximate time of your last activity** — for the "online now" indicator.
@@ -85,7 +85,7 @@
 		- **Google Cloud Translation** — the text you asked to translate, and nothing identifying you.
 		- **RevenueCat** — your LangX user id and your purchase events, so we know whether your subscription is active. Payment itself is taken by Apple, Google or Stripe, and none of them send us your card details.
 		- **Expo's push service**, and through it Apple's and Google's push infrastructure — your push token and the text of the notification. A new-message notification includes the beginning of the message, because that is what makes it useful; if you would rather it did not, turn notifications off.
-		- **Cloudflare R2 or Backblaze B2**, our object storage — your photos and voice messages, to host them.
+		- **Cloudflare R2 or Backblaze B2**, our object storage — your photos, videos and voice messages, to host them.
 		- **Sentry**, our error reporting service — the details of a server error, with your user id attached so we can tell whether a fault affected one account or everybody. It is configured never to send request bodies, cookies or authentication headers, so message contents and session tokens do not reach it.
 		- **Google and Apple**, if you choose to sign in with them — they tell us your email address and name; we tell them nothing about what you do in LangX.
 
@@ -145,7 +145,7 @@
 
 		We retain your information for as long as your account exists, and as required by applicable laws.
 
-		When you delete your account it becomes invisible immediately and every session is ended. The data is permanently removed 30 days later; signing back in within those 30 days cancels the deletion. Your photos and voice messages are removed from storage as well as from the database, so nothing stays reachable by URL.
+		When you delete your account it becomes invisible immediately and every session is ended. The data is permanently removed 30 days later; signing back in within those 30 days cancels the deletion. Your photos, videos and voice messages are removed from storage as well as from the database, so nothing stays reachable by URL.
 
 		Three exceptions are worth stating plainly:
 

--- a/src/lib/data/features.ts
+++ b/src/lib/data/features.ts
@@ -19,10 +19,11 @@ export default [
 		tags: [{ label: 'Translation' }]
 	},
 	{
-		name: 'Voice and photo messages',
-		description: 'Practise pronunciation with voice notes, and show what you mean with a photo.',
+		name: 'Voice, photo and video messages',
+		description:
+			'Practise pronunciation with voice notes, and show what you mean with photos or a short video.',
 		image: 'images/features/3.png',
-		tags: [{ label: 'Voice & Photos' }]
+		tags: [{ label: 'Voice, Photos & Video' }]
 	},
 	{
 		name: 'Filters',

--- a/src/lib/data/plans.ts
+++ b/src/lib/data/plans.ts
@@ -38,7 +38,10 @@ export const plans: Plan[] = [
 			{ label: '20 translations a day' },
 			{ label: '1 language you are learning, 1 you speak natively' },
 			{ label: 'Filters: country, age and level' },
-			{ label: 'Unlimited photos, videos and voice notes' },
+			{
+				label: '50 messages with a photo, video or voice note a day',
+				note: 'A ceiling on abuse, not a paywall — a normal conversation never reaches it.'
+			},
 			{ label: '6 photos on your profile' }
 		]
 	},

--- a/src/lib/data/plans.ts
+++ b/src/lib/data/plans.ts
@@ -39,7 +39,7 @@ export const plans: Plan[] = [
 			{ label: '1 language you are learning, 1 you speak natively' },
 			{ label: 'Filters: country, age and level' },
 			{
-				label: '50 photos and voice messages a day',
+				label: '50 photo, video or voice messages a day',
 				note: 'A ceiling on abuse, not a paywall — a normal conversation never reaches it.'
 			},
 			{ label: '6 photos on your profile' }

--- a/src/lib/data/plans.ts
+++ b/src/lib/data/plans.ts
@@ -38,10 +38,7 @@ export const plans: Plan[] = [
 			{ label: '20 translations a day' },
 			{ label: '1 language you are learning, 1 you speak natively' },
 			{ label: 'Filters: country, age and level' },
-			{
-				label: '50 messages with a photo, video or voice note a day',
-				note: 'A ceiling on abuse, not a paywall — a normal conversation never reaches it.'
-			},
+			{ label: 'Unlimited photos, videos and voice notes' },
 			{ label: '6 photos on your profile' }
 		]
 	},

--- a/src/lib/data/plans.ts
+++ b/src/lib/data/plans.ts
@@ -39,7 +39,7 @@ export const plans: Plan[] = [
 			{ label: '1 language you are learning, 1 you speak natively' },
 			{ label: 'Filters: country, age and level' },
 			{
-				label: '50 photo, video or voice messages a day',
+				label: '50 messages with a photo, video or voice note a day',
 				note: 'A ceiling on abuse, not a paywall — a normal conversation never reaches it.'
 			},
 			{ label: '6 photos on your profile' }

--- a/src/lib/data/plans.ts
+++ b/src/lib/data/plans.ts
@@ -32,16 +32,17 @@ export const plans: Plan[] = [
 		name: 'Free',
 		tagline: 'A real plan, not a trial.',
 		points: [
+			{ label: 'Unlimited text messages' },
+			{
+				label: '50 messages a day with a photo, video or voice note',
+				note: 'A ceiling on abuse, not a paywall — a normal conversation never reaches it.'
+			},
 			{ label: 'Unlimited replies to anyone who writes to you' },
 			{ label: 'Unlimited corrections' },
 			{ label: '5 new conversations a day' },
 			{ label: '20 translations a day' },
 			{ label: '1 language you are learning, 1 you speak natively' },
 			{ label: 'Filters: country, age and level' },
-			{
-				label: '50 messages with a photo, video or voice note a day',
-				note: 'A ceiling on abuse, not a paywall — a normal conversation never reaches it.'
-			},
 			{ label: '6 photos on your profile' }
 		]
 	},


### PR DESCRIPTION
Three things, all copy, no code.

**Video exists.** The feature card said photos and voice notes; a message carries short videos now, and up to six attachments rather than one.

**The free plan's line said the wrong thing.** "50 photos and voice messages a day" reads as a cap on messages, and there has never been one — replies and corrections are listed as unlimited two lines above it. The quota counts messages that *carry* something, not files: six photos in one message is one unit. So the line becomes "50 messages with a photo, video or voice note a day". The number and the note behind it are unchanged.

**The privacy policy now names video.** Three lines there and one on the deletion page listed "photos and voice messages" as what a conversation stores, what the object storage holds and what deletion removes. Incomplete rather than stale, which for a privacy policy is the difference that matters. Handling is unchanged — a video is stored, served and deleted on the same path as a photo — and Play's data-safety category is already "Photos and videos", so no form changes.

Android 2.0.0 is live at 100% and the web app is deployed, so every claim here is true today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)