### PR TITLE
Canonicalise the tools pages without a trailing slash

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -68,6 +68,10 @@ jobs:
       # under us — but a branch reference is how an unrelated upstream commit
       # gets to run in our deploy, which is worth closing whether or not this
       # particular one is asleep.
+      # The list is explicit because the "https://langx.io/*" entry below is a
+      # wildcard purge, which Cloudflare only honours on Enterprise — on this
+      # plan it silently does nothing. robots.txt was served from a fourteen
+      # hour old cache after the tools deploy for exactly that reason.
       - name: Purge cache
         uses: jakejarvis/cloudflare-purge-action@v0.3.0
         env:
@@ -86,5 +90,8 @@ jobs:
               "https://langx.io/privacy-policy",
               "https://langx.io/cookie-policy",
               "https://langx.io/data-deletion",
+              "https://langx.io/robots.txt",
+              "https://langx.io/tools",
+              "https://langx.io/tools/most-common-words",
               "https://langx.io/*"
             ]

--- a/src/lib/components/organisms/Footer.svelte
+++ b/src/lib/components/organisms/Footer.svelte
@@ -25,7 +25,7 @@
 				{ label: 'Good first issues', href: 'https://github.com/langx/langx/contribute' },
 				{ label: 'Releases', href: 'https://github.com/langx/langx/releases' },
 				{ label: 'Docs', href: 'https://docs.langx.io' },
-				{ label: 'Word lists', href: '/tools/most-common-words/' },
+				{ label: 'Word lists', href: '/tools/most-common-words' },
 				{ label: 'Status', href: 'https://status.langx.io' },
 				{ label: 'Branding', href: 'https://github.com/langx/branding' }
 			]

--- a/src/lib/components/organisms/Header.svelte
+++ b/src/lib/components/organisms/Header.svelte
@@ -11,7 +11,7 @@
 	const links = [
 		{ href: '/#how', label: 'How it works' },
 		{ href: '/pro', label: 'Plans' },
-		{ href: '/tools/most-common-words/', label: 'Word lists' },
+		{ href: '/tools/most-common-words', label: 'Word lists' },
 		{ href: '/blog', label: 'Blog' },
 		{ href: 'https://docs.langx.io', label: 'Docs', external: true }
 	];

--- a/src/routes/(site)/tools/+page.svelte
+++ b/src/routes/(site)/tools/+page.svelte
@@ -8,7 +8,7 @@
 
 <Seo
 	title="Free language tools"
-	path="/tools/"
+	path="/tools"
 	description="Free tools for language learners from LangX — starting with frequency-ranked word lists for {WORD_LISTS.length} languages, each word with its meaning in English."
 />
 
@@ -20,7 +20,7 @@
 
 	<ul class="rows" role="list">
 		<li>
-			<a href="/tools/most-common-words/">
+			<a href="/tools/most-common-words">
 				<span class="name">The most common words in {WORD_LISTS.length} languages</span>
 				<span class="what">
 					{nf.format(totalWords)} words ranked by how often they are actually spoken, each with its meaning

--- a/src/routes/(site)/tools/most-common-words/+page.svelte
+++ b/src/routes/(site)/tools/most-common-words/+page.svelte
@@ -37,7 +37,7 @@
 			{
 				'@type': 'BreadcrumbList',
 				itemListElement: [
-					{ '@type': 'ListItem', position: 1, name: 'Tools', item: `${siteBaseUrl}/tools/` },
+					{ '@type': 'ListItem', position: 1, name: 'Tools', item: `${siteBaseUrl}/tools` },
 					{ '@type': 'ListItem', position: 2, name: 'Most common words' }
 				]
 			},
@@ -65,7 +65,7 @@
 
 <Seo
 	title="The most common words in {WORD_LISTS.length} languages"
-	path="/tools/most-common-words/"
+	path="/tools/most-common-words"
 	description="Frequency-ranked word lists for {WORD_LISTS.length} languages — {nf.format(
 		totalWords
 	)} words in all, each with its meaning in English. Free to browse and download."
@@ -94,7 +94,7 @@
 		<ul class="grid" role="list">
 			{#each popular as l}
 				<li>
-					<a href="/tools/most-common-words/{l.slug}/">
+					<a href="/tools/most-common-words/{l.slug}">
 						<span class="name">{l.name}</span>
 						<span class="native" lang={l.code}>{l.nativeName}</span>
 						<span class="n">{nf.format(l.count)} words</span>
@@ -109,7 +109,7 @@
 		<ul class="rows" role="list">
 			{#each WORD_LISTS as l}
 				<li>
-					<a href="/tools/most-common-words/{l.slug}/">
+					<a href="/tools/most-common-words/{l.slug}">
 						<span class="name">{l.name}</span>
 						<span class="native" lang={l.code}>{l.nativeName}</span>
 						<span class="n">{nf.format(l.count)}</span>

--- a/src/routes/(site)/tools/most-common-words/[language]/+page.svelte
+++ b/src/routes/(site)/tools/most-common-words/[language]/+page.svelte
@@ -19,7 +19,7 @@
 	$: ({ meta, rows, rendered, others } = data);
 
 	const nf = new Intl.NumberFormat('en-US');
-	$: path = `/tools/most-common-words/${meta.slug}/`;
+	$: path = `/tools/most-common-words/${meta.slug}`;
 	$: fileUrl = `/data/most-common-words/${meta.slug}.tsv`;
 	$: title = `${nf.format(meta.count)} most common ${meta.name} words`;
 
@@ -80,12 +80,12 @@
 				{
 					'@type': 'BreadcrumbList',
 					itemListElement: [
-						{ '@type': 'ListItem', position: 1, name: 'Tools', item: `${siteBaseUrl}/tools/` },
+						{ '@type': 'ListItem', position: 1, name: 'Tools', item: `${siteBaseUrl}/tools` },
 						{
 							'@type': 'ListItem',
 							position: 2,
 							name: 'Most common words',
-							item: `${siteBaseUrl}/tools/most-common-words/`
+							item: `${siteBaseUrl}/tools/most-common-words`
 						},
 						{ '@type': 'ListItem', position: 3, name: m.name }
 					]
@@ -245,7 +245,7 @@
 		<h2>Other languages</h2>
 		<ul role="list">
 			{#each others as o}
-				<li><a href="/tools/most-common-words/{o.slug}/">{o.name}</a></li>
+				<li><a href="/tools/most-common-words/{o.slug}">{o.name}</a></li>
 			{/each}
 		</ul>
 	</nav>


### PR DESCRIPTION
Follow-up to #136, found by checking the deployed pages rather than the build.

**The canonical tags pointed at redirects.** Cloudflare Pages serves the no-slash form and 308s the slashed one — `/pro/` has always redirected to `/pro` — and every pre-existing page canonicalises accordingly (`https://langx.io/pro`). The tools pages shipped with `https://langx.io/tools/most-common-words/spanish/`, so each page's self-referencing canonical was a redirect, on the pages whose whole point is search. Fixed for the canonical tags, the internal links and the JSON-LD breadcrumb items.

**robots.txt was still stale after the deploy.** The purge step's `"https://langx.io/*"` entry is a wildcard purge, which Cloudflare only honours on Enterprise; on this plan it silently does nothing. robots.txt was not in the explicit list, so fourteen hours after the deploy it was still being served without its new `Sitemap:` line. It and the two tools URLs are now listed explicitly.

The pages themselves are live and fine at the no-slash URLs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
