### PR TITLE
Download any slice of a word list, as CSV or text

### DIFF
--- a/src/routes/(site)/tools/most-common-words/+page.svelte
+++ b/src/routes/(site)/tools/most-common-words/+page.svelte
@@ -82,6 +82,47 @@
 
 	$: nothing = ran && !searching && !groups.length;
 
+	/**
+	 * The row links straight at the raw .tsv so it works without JavaScript, but
+	 * a tab-separated file opens as one column in most things people own. With
+	 * JavaScript we intercept and hand over a CSV instead.
+	 */
+	let building = '';
+
+	function csvCell(value: string) {
+		return /[",\n]/.test(value) ? `"${value.replace(/"/g, '""')}"` : value;
+	}
+
+	async function downloadCsv(event: MouseEvent, l: (typeof WORD_LISTS)[number]) {
+		event.preventDefault();
+		if (building) return;
+		building = l.slug;
+		try {
+			const res = await fetch(`/data/most-common-words/${l.slug}.tsv`);
+			const rows = (await res.text())
+				.split('\n')
+				.slice(1)
+				.filter(Boolean)
+				.map((line) => line.split('\t'));
+			const body =
+				'rank,word,english\n' +
+				rows
+					.map(([rank, word, english]) => `${rank},${csvCell(word)},${csvCell(english ?? '')}`)
+					.join('\n');
+			const url = URL.createObjectURL(new Blob([body], { type: 'text/csv;charset=utf-8' }));
+			const a = document.createElement('a');
+			a.href = url;
+			a.download = `${l.slug}-most-common-words.csv`;
+			a.click();
+			URL.revokeObjectURL(url);
+		} catch {
+			// Fall back to the plain file rather than leaving them with nothing.
+			window.location.href = `/data/most-common-words/${l.slug}.tsv`;
+		} finally {
+			building = '';
+		}
+	}
+
 	const faq = [
 		{
 			q: 'Where do these lists come from?',
@@ -280,6 +321,8 @@
 						href="/data/most-common-words/{l.slug}.tsv"
 						download
 						aria-label="Download the {l.name} list, {nf.format(l.count)} words"
+						aria-busy={building === l.slug}
+						on:click={(e) => downloadCsv(e, l)}
 					>
 						<svg viewBox="0 0 24 24" aria-hidden="true">
 							<path d="M12 4v11" />

--- a/src/routes/(site)/tools/most-common-words/[language]/+page.svelte
+++ b/src/routes/(site)/tools/most-common-words/[language]/+page.svelte
@@ -67,6 +67,61 @@
 		}
 	}
 
+	/**
+	 * Downloads are built in the browser rather than shipped as files. Six tiers
+	 * across fifty-three languages would be 300 more files in the repo for data
+	 * that is already here, and this way the tier the reader picked is the tier
+	 * they get.
+	 */
+	let downloading = false;
+
+	function csvCell(value: string) {
+		// A meaning like "of, from" has to be quoted or the column splits.
+		return /[",\n]/.test(value) ? `"${value.replace(/"/g, '""')}"` : value;
+	}
+
+	async function download(format: 'csv' | 'txt', count: number) {
+		if (downloading) return;
+		downloading = true;
+		try {
+			if (count > rendered) await loadAll();
+			const list = (loaded ? all : rows).slice(0, count);
+			const name = `${meta.slug}-${count === meta.count ? 'all' : `top-${count}`}-words`;
+
+			let body: string;
+			if (format === 'csv') {
+				body =
+					'rank,word,english\n' +
+					list.map((r) => `${r.rank},${csvCell(r.word)},${csvCell(r.english)}`).join('\n');
+			} else {
+				// Plain text carries the credit, because a file that travels away
+				// from this page still has to name where the data came from.
+				const width = Math.max(...list.map((r) => r.word.length)) + 2;
+				body =
+					`# The ${nf.format(count)} most common ${meta.name} words\n` +
+					`# From langx.io/tools/most-common-words/${meta.slug}\n` +
+					`# Frequencies: OpenSubtitles via hermitdave/FrequencyWords. ` +
+					`Meanings: Wiktextract. Both CC BY-SA 4.0, as is this list.\n\n` +
+					list
+						.map((r) => `${String(r.rank).padStart(6)}  ${r.word.padEnd(width)}${r.english}`)
+						.join('\n');
+			}
+
+			const url = URL.createObjectURL(
+				new Blob([body], {
+					type: format === 'csv' ? 'text/csv;charset=utf-8' : 'text/plain;charset=utf-8'
+				})
+			);
+			const a = document.createElement('a');
+			a.href = url;
+			a.download = `${name}.${format}`;
+			a.click();
+			URL.revokeObjectURL(url);
+		} finally {
+			downloading = false;
+		}
+	}
+
 	function jump(n: number) {
 		query = '';
 		limit = n;
@@ -208,14 +263,30 @@
 	<section class="download">
 		<h2>Take the list with you</h2>
 		<p>
-			The whole list as a tab-separated file — rank, word, meaning — about
-			{Math.round(meta.bytes / 1024)} KB. It opens in any spreadsheet.
+			Rank, word and meaning in three columns. Pick how much of the list you want — the same slices
+			as the buttons above.
 		</p>
-		<p>
-			<a class="quiet-link" href={fileUrl} download
-				>Download all {nf.format(meta.count)} {meta.name} words</a
-			>
+
+		<div class="dl-grid">
+			{#each tiers as n}
+				<div class="dl-row">
+					<span class="dl-n">Top {nf.format(n)}</span>
+					<button type="button" on:click={() => download('csv', n)} disabled={downloading}>
+						CSV
+					</button>
+					<button type="button" on:click={() => download('txt', n)} disabled={downloading}>
+						Text
+					</button>
+				</div>
+			{/each}
+		</div>
+
+		<p class="dl-note">
+			CSV opens straight into Excel, Numbers or Google Sheets, and imports into Anki. For a
+			printable copy, choose a size above and use your browser's print command — the page prints as
+			a clean list, and every script comes out right.
 		</p>
+
 		<p class="credit">
 			Frequencies come from the OpenSubtitles corpus via
 			<a
@@ -224,7 +295,8 @@
 				target="_blank">hermitdave/FrequencyWords</a
 			>; English meanings from
 			<a href="https://kaikki.org" rel="noopener noreferrer" target="_blank">Wiktextract</a>. Both
-			are CC BY-SA 4.0, and so is this list.
+			are CC BY-SA 4.0, and so is this list — keep the credit if you pass it on. The
+			<a href={fileUrl} download>raw data file</a> is here too.
 		</p>
 	</section>
 
@@ -448,9 +520,65 @@
 		}
 	}
 
-	.quiet-link {
+	.dl-grid {
+		display: grid;
+		grid-template-columns: repeat(auto-fill, minmax(230px, 1fr));
+		gap: 0 var(--space-lg);
+		border-top: 1px solid var(--color--border);
+		margin-top: var(--space-md);
+	}
+
+	.dl-row {
+		display: flex;
+		align-items: center;
+		gap: var(--space-2xs);
+		padding: 11px 0;
+		border-bottom: 1px solid var(--color--border);
+	}
+
+	.dl-n {
+		flex: 1 1 auto;
+		font-family: var(--font--title);
+		font-weight: 800;
+		font-variant-numeric: tabular-nums;
+	}
+
+	// Blue means interactive; a download is not the page's committing action, so
+	// it is never a second yellow.
+	.dl-row button {
+		flex: 0 0 auto;
+		height: 34px;
+		padding: 0 14px;
+		border-radius: var(--radius-pill);
+		border: 1px solid var(--color--border);
+		background: none;
 		color: var(--color--accent);
+		font-family: var(--font--default);
+		font-size: 0.8125rem;
 		font-weight: 600;
+		cursor: pointer;
+		transition: background-color var(--dur-fast) ease, border-color var(--dur-fast) ease,
+			transform var(--dur-press) var(--ease-out);
+
+		&:active {
+			transform: scale(0.95);
+		}
+
+		&:disabled {
+			opacity: 0.5;
+			cursor: default;
+		}
+
+		@media (hover: hover) and (pointer: fine) {
+			&:not(:disabled):hover {
+				background: var(--color--accent-tint);
+				border-color: transparent;
+			}
+		}
+	}
+
+	.dl-note {
+		margin-top: var(--space-sm);
 	}
 
 	.credit {
@@ -481,6 +609,42 @@
 			&:hover {
 				color: var(--color--text);
 			}
+		}
+	}
+
+	@media print {
+		:global(header.header),
+		:global(footer),
+		.controls,
+		.more,
+		.download,
+		.cta,
+		.others,
+		.status {
+			display: none !important;
+		}
+
+		.words {
+			border-top: 0;
+		}
+
+		.words th,
+		.words td {
+			padding: 4px 8px 4px 0;
+			font-size: 10pt;
+		}
+
+		// A word split across a page break is unreadable in a printed list.
+		.words tr {
+			break-inside: avoid;
+		}
+
+		.words thead {
+			display: table-header-group;
+		}
+
+		.intro {
+			max-width: none;
 		}
 	}
 </style>


### PR DESCRIPTION
Two complaints, one cause.

**The meanings were never missing from the download.** The file has carried `rank`, `word`, `english` in three columns since it was built. What was missing was a format people can open: a `.tsv` opens as a single column in most things anyone actually owns, so the meanings were there and invisible.

## What changed

- **CSV is what a download button now gives you**, properly quoted — a meaning like `of, from` splits a column otherwise. Text is the other option, and carries the attribution in its header, because a file that travels away from this page still has to name where the data came from.
- **The tiers on the page are now the tiers you can take.** Top 100 through the whole list, each with its own pair of buttons — the same slices as the jump chips above them.
- **The hub's per-language download does the same**, converting on the way. Its `href` still points at the raw file, so it works with no JavaScript at all.

## Two decisions worth stating

**Downloads are built in the browser, not shipped as files.** Six slices across 53 languages would be ~300 more files in the repo for data that is already there, and this way the slice you picked is the slice you get. Above 1,000 words it fetches the rest of the list first.

**PDF is the browser's own print export, not a generated one.** A print stylesheet strips the page to the list. Generating PDFs here would mean embedding a font for each of 53 scripts — Cyrillic, Arabic, Devanagari, Han, Hangul, Thai — and the usual JS PDF libraries ship none of them, so the output would be boxes for a good half of the languages. The browser already has fonts for all of it.

Verified in the browser: `spanish-top-5000-words.csv` comes out with 5,001 rows and `1,de,"of, from"` correctly quoted; the text format carries its credit header; the hub button produces `turkish-most-common-words.csv` with 10,001 rows.

`npm run lint`, `npm run check` (0 errors), the build and the Impeccable detector (0 findings) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
