### PR TITLE
Say that the app has analytics, because it does

### DIFF
--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -35,8 +35,13 @@ replace langx.io and send visitors to the app (iOS, Android, web).
 
 Matching runs in **both directions**, and **corrections are unlimited on every
 plan** — the part that teaches is never rationed. The app and API are open
-source (BSD-3) and self-hostable. No ads, no advertising identifiers, no
-third-party analytics SDK. "Open source alternative to Tandem" is an existing,
+source (BSD-3) and self-hostable. No ads and no advertising identifiers. There **is** a
+third-party analytics SDK — PostHog, on its EU cloud, screen names and a short
+list of events keyed by the LangX user id, no session recording, off in
+Settings → Privacy. It arrived after this file was written and after the
+privacy policy said there was none; both have been corrected. Any claim about
+tracking on a new page has to be checked against
+`langx/docs/store/privacy-data-safety.md`, which is written from the code. "Open source alternative to Tandem" is an existing,
 published line.
 
 ## Operating Context

--- a/src/lib/components/organisms/CookiePolicy.svelte
+++ b/src/lib/components/organisms/CookiePolicy.svelte
@@ -22,7 +22,9 @@
 
 		3.3 Analytics
 
-		**There are none.** LangX version 1 ran a self-hosted analytics service on langx.io; it was retired and version 2 replaced it with nothing. This site sets no analytics cookie, counts no page views, and the app contains no analytics or session-recording SDK. If that ever changes, this section will say so before it does, and anything of the kind will be something you can turn off.
+		**None on this site.** LangX version 1 ran a self-hosted analytics service on langx.io; it was retired and version 2 replaced it with nothing. This site sets no analytics cookie and counts no page views.
+
+		The **app** is a different answer, and this section used to give the wrong one. It sends usage analytics to PostHog — screen names, a short list of events and your LangX user id, with no session recording and nothing that carries the content of a message. That is described in full in section 2.4 of the [privacy policy](/privacy-policy), and it is turned off in Settings → Privacy → Share usage data. It arrived without this page being updated first, which is not how it was supposed to go; the promise to say so beforehand stands for anything that comes next.
 
 		3.4 Third-party cookies
 

--- a/src/lib/components/organisms/PrivacyPolicy.svelte
+++ b/src/lib/components/organisms/PrivacyPolicy.svelte
@@ -46,6 +46,20 @@
 
 		One thing is derived from it: **your country**, as a two-letter code, when you create your profile. It is shown on your profile and used by the Pro country filter, which is only worth having if the country is not something anyone can simply type. The address itself is not kept — only the country it resolved to. If it is wrong, granting location permission in the app replaces it with the country your device reports; nothing else can change it.
 
+		2.4 Usage analytics
+
+		The app sends usage analytics to **PostHog**, on its European cloud. This is a third-party product-analytics SDK and it is worth saying plainly, because an earlier version of this policy said there was none.
+
+		What reaches it is the name of the screen you are on, a short list of events — a message sent, onboarding finished, the paywall shown, a purchase started and finished — and your LangX user id. Nothing else. The list of events is fixed in the code as a closed type, and the keys that would carry personal content (a message body, an email address, a display name, a handle) are refused when the app is built rather than filtered afterwards.
+
+		Three settings make the rest of the answer, and each is set in the app's source:
+
+		- **No session recording.** Screen replay is switched off. Nobody watches a recording of you using the app, because none is made.
+		- **No location from analytics.** PostHog is told not to turn the connection's IP address into a country, so analytics adds nothing to what section 3 describes.
+		- **The identifier is ours.** You are identified by your LangX user id and nothing else — no email address, no name. That is also what lets a deleted account's events be found and deleted with it.
+
+		It is on by default and it is optional: **Settings → Privacy → Share usage data** turns it off, and a refusal made before signing in is honoured. There is no analytics on this website — no page-view counter, no analytics cookie, nothing.
+
 	3. Approximate Location, and Only If You Ask For It
 
 		Polyglot includes a "Nearby" sort that orders people by roughly how far away they are. It is the only feature that uses location anywhere in LangX, and this is exactly what it does.
@@ -61,7 +75,7 @@
 		Stating this precisely is what makes the rest of the policy credible.
 
 		- **No precise location.** See section 3: the app asks for the coarsest reading your device will give and rounds it before storing it. A street-level position is never collected.
-		- **No analytics, and no analytics SDK.** LangX version 1 ran a self-hosted analytics service; version 2 ships none. There is no product-analytics or session-recording SDK in the app or on this website, and no page-view counter on langx.io.
+		- **No session recording, and no analytics on this website.** The app does send usage analytics — section 2.4 says exactly what, and how to turn it off — but nothing records your screen, and langx.io itself has no analytics of any kind: no page-view counter, no analytics cookie.
 		- **No advertising identifiers.** No IDFA, no Android advertising ID, no ad network, and nothing is sold or passed to a data broker.
 		- **No tracking across other apps or websites.**
 		- **No contacts, no calendar, no photos beyond the ones you choose to upload, no microphone access outside recording a voice message you send, no health data.**
@@ -87,6 +101,7 @@
 		- **Expo's push service**, and through it Apple's and Google's push infrastructure — your push token and the text of the notification. A new-message notification includes the beginning of the message, because that is what makes it useful; if you would rather it did not, turn notifications off.
 		- **Cloudflare R2 or Backblaze B2**, our object storage — your photos, videos and voice messages, to host them.
 		- **Sentry**, our error reporting service — the details of a server error, with your user id attached so we can tell whether a fault affected one account or everybody. It is configured never to send request bodies, cookies or authentication headers, so message contents and session tokens do not reach it.
+		- **PostHog**, our analytics provider, on its European cloud — the screen names, events and user id described in section 2.4. It processes them for us and for nothing of its own, and you can switch this off in Settings.
 		- **Google and Apple**, if you choose to sign in with them — they tell us your email address and name; we tell them nothing about what you do in LangX.
 
 		Our servers run on **Fly.io** in Frankfurt, our database is **MongoDB Atlas**, and langx.io is served through **Cloudflare**. These providers host and deliver the service and do not use your data for any purpose of their own.
@@ -131,7 +146,11 @@
 
 		You can withdraw your location at any time from the switch in Settings, which deletes the stored point. You do not have to delete or export your account to do it.
 
-		10.5 Notifications and email
+		10.5 Usage analytics
+
+		**Settings → Privacy → Share usage data** turns off the analytics described in section 2.4. Switching it off stops the app sending anything further and discards the identifier it was using. A refusal made before you sign in is honoured.
+
+		10.6 Notifications and email
 
 		Notifications are switched per kind and per channel in Settings → Notifications: messages, streak reminders, badges, profile visits and marketing, each with a separate switch for your phone and for email. You can also turn off push entirely from your device settings.
 

--- a/src/lib/components/organisms/Story.svelte
+++ b/src/lib/components/organisms/Story.svelte
@@ -77,7 +77,7 @@
 				<li>
 					<UiIcon name="check" size={22} strokeWidth={3} /><span>Translate right in the chat</span>
 				</li>
-				<li><UiIcon name="check" size={22} strokeWidth={3} /><span>No ads, no trackers</span></li>
+				<li><UiIcon name="check" size={22} strokeWidth={3} /><span>No ads, nothing sold</span></li>
 			</ul>
 		</div>
 	</section>

--- a/src/lib/data/features.ts
+++ b/src/lib/data/features.ts
@@ -43,7 +43,8 @@ export default [
 	},
 	{
 		name: 'Your data stays yours',
-		description: 'Download or delete everything from inside the app. No ads, no trackers.',
+		description:
+			'Download or delete everything from inside the app. No ads, and nothing sold to anyone.',
 		image: 'images/features/6.png',
 		tags: [{ label: 'Privacy' }]
 	},

--- a/src/routes/(blog-article)/langx-v2-what-changes-and-why/+page.md
+++ b/src/routes/(blog-article)/langx-v2-what-changes-and-why/+page.md
@@ -69,6 +69,15 @@ revenue. We would rather charge for filters than sell your attention: there are
 no ads, no advertising identifiers, and no third-party analytics SDK. The code
 stays open source under BSD-3, and you can host your own instance.
 
+> **Note added 4 September 2026.** The sentence above is no longer true in one
+> respect, and it is left standing rather than quietly edited. The app now
+> includes a third-party analytics SDK: PostHog, on its European cloud, which
+> receives screen names, a short list of events and your LangX user id — no
+> session recording, and nothing carrying the content of a message. It is off
+> in Settings → Privacy → Share usage data, and the
+> [privacy policy](/privacy-policy) describes it in full. There are still no
+> ads and no advertising identifiers.
+
 The full comparison is on the [plans page](/pro).
 
 ## The second: LangX Token is not what the litepaper described


### PR DESCRIPTION
**This changes legal text. It should be read, not merged on CI going green.**

The privacy policy said, in the section whose whole job is to be precise:

> **No analytics, and no analytics SDK.** … There is no product-analytics or session-recording SDK in the app or on this website.

The cookie policy said the app contains none, and added:

> **If that ever changes, this section will say so before it does.**

`apps/mobile` has shipped `posthog-react-native ^4.67.0` since early September, wired up in `src/lib/analytics.ts` with a closed event union and property sanitisation. The section that promised to speak first never spoke.

## What is actually true, and what the policy now says

PostHog, on its EU cloud, receives **screen names, five funnel events** (`message_sent`, `onboarding_completed`, `paywall_viewed`, `purchase_started`, `purchase_finished`) **and the LangX user id**.

- Session replay is **off** (`enableSessionReplay: false`)
- Geo-IP resolution is **off** (`disableGeoip: true`)
- Keys that would carry a message body, email, name or handle are refused **at build time**, not filtered afterwards (`FORBIDDEN_PROPERTY_KEYS`)
- On by default, off in **Settings → Privacy → Share usage data**
- This website still has no analytics of any kind — which is why the cookie policy's answer now splits in two

To be fair to what was built: this is a careful integration, and `langx/docs/store/privacy-data-safety.md` documented it correctly from the code all along. What went wrong is that the website's policies were never updated to match.

## What changed

| File | |
| --- | --- |
| `PrivacyPolicy.svelte` | New **2.4 Usage analytics**; the false bullet in §4 narrowed to what is still true; PostHog added to §6 third parties; new **10.5** for the opt-out |
| `CookiePolicy.svelte` | Answer split: none on the site, and what the app does — including that this page should have said so first |
| `Story.svelte`, `features.ts` | "No ads, no trackers" → "No ads, nothing sold". A reader turns "no trackers" into "nothing watches what I do", which is no longer true |
| v2 announcement post | Original sentence kept, with a dated note under it. It was true when published; rewriting it would hide that this happened |
| `PRODUCT.md` | Carried the claim, and is what other work reads before writing copy. Now says the opposite and points at the store doc |

## Worth deciding separately

The fix here is to the *pages*. The other available fix is to the *app* — if analytics-on-by-default is not what you want, this PR does not settle that, it just stops the site saying something untrue while you decide.

`npm run lint`, `npm run check` (0 errors) and the build all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
