### PR TITLE
Put a globe in the hero instead of the phone

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,9 @@
 			"version": "0.2.9",
 			"license": "MIT",
 			"dependencies": {
-				"@fontsource/nunito": "^5.3.0"
+				"@fontsource/nunito": "^5.3.0",
+				"@types/three": "^0.185.4",
+				"three": "^0.185.1"
 			},
 			"devDependencies": {
 				"@neoconfetti/svelte": "^1.0.0",
@@ -64,6 +66,12 @@
 			"engines": {
 				"node": ">=6.0.0"
 			}
+		},
+		"node_modules/@dimforge/rapier3d-compat": {
+			"version": "0.12.0",
+			"resolved": "https://registry.npmjs.org/@dimforge/rapier3d-compat/-/rapier3d-compat-0.12.0.tgz",
+			"integrity": "sha512-uekIGetywIgopfD97oDL5PfeezkFpNhwlzlaEYNOA0N6ghdsOvh/HYjSMek5Q2O1PYvRSDFcqFVJl4r4ZBwOow==",
+			"license": "Apache-2.0"
 		},
 		"node_modules/@esbuild/android-arm": {
 			"version": "0.18.20",
@@ -769,6 +777,12 @@
 				"vite": "^4.0.0"
 			}
 		},
+		"node_modules/@tweenjs/tween.js": {
+			"version": "23.1.3",
+			"resolved": "https://registry.npmjs.org/@tweenjs/tween.js/-/tween.js-23.1.3.tgz",
+			"integrity": "sha512-vJmvvwFxYuGnF2axRtPYocag6Clbb5YS7kLL+SO/TeVFzHqDIWrNKYtcsPMibjDx9O+bu+psAy9NKfWklassUA==",
+			"license": "MIT"
+		},
 		"node_modules/@types/chai": {
 			"version": "4.3.9",
 			"resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.3.9.tgz",
@@ -844,11 +858,37 @@
 			"integrity": "sha512-MMzuxN3GdFwskAnb6fz0orFvhfqi752yjaXylr0Rp4oDg5H0Zn1IuyRhDVvYOwAXoJirx2xuS16I3WjxnAIHiQ==",
 			"dev": true
 		},
+		"node_modules/@types/stats.js": {
+			"version": "0.17.4",
+			"resolved": "https://registry.npmjs.org/@types/stats.js/-/stats.js-0.17.4.tgz",
+			"integrity": "sha512-jIBvWWShCvlBqBNIZt0KAshWpvSjhkwkEu4ZUcASoAvhmrgAUI2t1dXrjSL4xXVLB4FznPrIsX3nKXFl/Dt4vA==",
+			"license": "MIT"
+		},
+		"node_modules/@types/three": {
+			"version": "0.185.4",
+			"resolved": "https://registry.npmjs.org/@types/three/-/three-0.185.4.tgz",
+			"integrity": "sha512-gAsBIC07NIFrxjbf7tH2t71c38uulFfk/RFoC7FNBSjMRAQ8J1x/RBvusX0N5PJouaYFJawXQqfCQ0RKUx/1nA==",
+			"license": "MIT",
+			"dependencies": {
+				"@dimforge/rapier3d-compat": "~0.12.0",
+				"@tweenjs/tween.js": "~23.1.3",
+				"@types/stats.js": "*",
+				"@types/webxr": ">=0.5.17",
+				"fflate": "~0.8.2",
+				"meshoptimizer": "~1.1.1"
+			}
+		},
 		"node_modules/@types/unist": {
 			"version": "2.0.9",
 			"resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.9.tgz",
 			"integrity": "sha512-zC0iXxAv1C1ERURduJueYzkzZ2zaGyc+P2c95hgkikHPr3z8EdUZOlgEQ5X0DRmwDZn+hekycQnoeiiRVrmilQ==",
 			"dev": true
+		},
+		"node_modules/@types/webxr": {
+			"version": "0.5.24",
+			"resolved": "https://registry.npmjs.org/@types/webxr/-/webxr-0.5.24.tgz",
+			"integrity": "sha512-h8fgEd/DpoS9CBrjEQXR+dIDraopAEfu4wYVNY2tEPwk60stPWhvZMf4Foo5FakuQ7HFZoa8WceaWFervK2Ovg==",
+			"license": "MIT"
 		},
 		"node_modules/@typescript-eslint/eslint-plugin": {
 			"version": "6.8.0",
@@ -2185,6 +2225,12 @@
 				"reusify": "^1.0.4"
 			}
 		},
+		"node_modules/fflate": {
+			"version": "0.8.3",
+			"resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.3.tgz",
+			"integrity": "sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==",
+			"license": "MIT"
+		},
 		"node_modules/file-entry-cache": {
 			"version": "6.0.1",
 			"resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
@@ -2819,6 +2865,12 @@
 			"engines": {
 				"node": ">= 8"
 			}
+		},
+		"node_modules/meshoptimizer": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/meshoptimizer/-/meshoptimizer-1.1.1.tgz",
+			"integrity": "sha512-oRFNWJRDA/WTrVj7NWvqa5HqE1t9MYDj2VaWirQCzCCrAd2GHrqR/sQezCxiWATPNlKTcRaPRHPJwIRoPBAp5g==",
+			"license": "MIT"
 		},
 		"node_modules/micromatch": {
 			"version": "4.0.8",
@@ -4203,6 +4255,12 @@
 			"resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
 			"integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
 			"dev": true
+		},
+		"node_modules/three": {
+			"version": "0.185.1",
+			"resolved": "https://registry.npmjs.org/three/-/three-0.185.1.tgz",
+			"integrity": "sha512-5aojFCXKwnjBRZvUnt3WFfEcvUJgkN5LlijRFN95hMy8WVkG4I0QNcJE+OuWvuJ0bOdStrbfXn0pkd6/QyiAlg==",
+			"license": "MIT"
 		},
 		"node_modules/tiny-glob": {
 			"version": "0.2.9",

--- a/package.json
+++ b/package.json
@@ -76,6 +76,8 @@
 	},
 	"type": "module",
 	"dependencies": {
-		"@fontsource/nunito": "^5.3.0"
+		"@fontsource/nunito": "^5.3.0",
+		"@types/three": "^0.185.4",
+		"three": "^0.185.1"
 	}
 }

--- a/src/lib/components/globe/Globe.svelte
+++ b/src/lib/components/globe/Globe.svelte
@@ -1,0 +1,101 @@
+<script lang="ts">
+	/**
+	 * A globe with arcs linking cities, for the hero. Three.js is loaded on
+	 * the client only, after mount, so the page prerenders without it and the
+	 * chunk only ships to the homepage.
+	 *
+	 * Colours come from the theme tokens on the element itself, so the globe
+	 * follows the light/dark switch. It stops rendering while off-screen or in
+	 * a hidden tab, and under reduced motion it draws one complete frame.
+	 */
+	import { onMount } from 'svelte';
+	import type { GlobeColors, GlobeHandle } from './scene';
+
+	export let label: string;
+
+	let container: HTMLDivElement;
+	let failed = false;
+
+	function readColors(): GlobeColors {
+		const style = getComputedStyle(container);
+		const token = (name: string) => style.getPropertyValue(`--color--${name}`).trim();
+		return {
+			surface: token('muted'),
+			dots: token('text-tertiary'),
+			arc: token('accent'),
+			city: token('primary')
+		};
+	}
+
+	onMount(() => {
+		let handle: GlobeHandle | undefined;
+		let cancelled = false;
+		const cleanups: Array<() => void> = [];
+
+		import('./scene').then(({ createGlobe }) => {
+			if (cancelled) return;
+			try {
+				handle = createGlobe(container, {
+					colors: readColors(),
+					animate: !window.matchMedia('(prefers-reduced-motion: reduce)').matches
+				});
+			} catch {
+				failed = true;
+				return;
+			}
+
+			const recolor = () => handle?.setColors(readColors());
+			const themeAttr = new MutationObserver(recolor);
+			themeAttr.observe(document.documentElement, {
+				attributes: true,
+				attributeFilter: ['data-theme']
+			});
+			const scheme = window.matchMedia('(prefers-color-scheme: dark)');
+			scheme.addEventListener('change', recolor);
+
+			let visible = true;
+			const sync = () => handle?.setPaused(!visible || document.hidden);
+			const inView = new IntersectionObserver(([entry]) => {
+				visible = entry.isIntersecting;
+				sync();
+			});
+			inView.observe(container);
+			document.addEventListener('visibilitychange', sync);
+
+			cleanups.push(() => {
+				themeAttr.disconnect();
+				scheme.removeEventListener('change', recolor);
+				inView.disconnect();
+				document.removeEventListener('visibilitychange', sync);
+			});
+		});
+
+		return () => {
+			cancelled = true;
+			for (const cleanup of cleanups) cleanup();
+			handle?.destroy();
+		};
+	});
+</script>
+
+<div class="globe" class:failed role="img" aria-label={label} bind:this={container} />
+
+<style lang="scss">
+	.globe {
+		width: 100%;
+		aspect-ratio: 1;
+		max-width: 520px;
+		margin: 0 auto;
+
+		&.failed {
+			display: none;
+		}
+
+		:global(canvas) {
+			display: block;
+			width: 100%;
+			height: 100%;
+			touch-action: pan-y;
+		}
+	}
+</style>

--- a/src/lib/components/globe/scene.ts
+++ b/src/lib/components/globe/scene.ts
@@ -1,0 +1,394 @@
+/**
+ * The hero globe: a dotted sphere, a handful of cities, and arcs that grow
+ * from one city to another, rest, fade, and start again somewhere else.
+ *
+ * Kept out of the Svelte component so Vite can tree-shake `three` into a
+ * chunk that only the homepage loads, and so nothing here runs during
+ * prerender — the component imports this module in `onMount`.
+ */
+import {
+	BufferGeometry,
+	Clock,
+	CubicBezierCurve3,
+	Float32BufferAttribute,
+	Group,
+	MathUtils,
+	Mesh,
+	MeshBasicMaterial,
+	PerspectiveCamera,
+	Points,
+	PointsMaterial,
+	Scene,
+	SphereGeometry,
+	Texture,
+	TubeGeometry,
+	Vector3,
+	WebGLRenderer
+} from 'three';
+
+export interface GlobeColors {
+	/** The disc itself. Opaque, so arcs and dots on the far side are hidden. */
+	surface: string;
+	dots: string;
+	arc: string;
+	city: string;
+}
+
+export interface GlobeOptions {
+	colors: GlobeColors;
+	/** `false` draws one still frame with every arc complete (reduced motion). */
+	animate: boolean;
+}
+
+export interface GlobeHandle {
+	setColors(colors: GlobeColors): void;
+	setPaused(paused: boolean): void;
+	destroy(): void;
+}
+
+const RADIUS = 1;
+const DOT_COUNT = 1600;
+// Half the arcs sit on the far side at any moment, so six reads as three.
+const ARC_COUNT = 6;
+// Seconds. An arc grows, rests, fades, then picks a new pair of cities.
+const GROW = 1.4;
+const HOLD = 1.6;
+const FADE = 0.8;
+const SPIN = 0.06; // radians per second
+const TILT = MathUtils.degToRad(23.4);
+const TUBE_SEGMENTS = 64;
+const TUBE_RADIAL = 5;
+const TUBE_RADIUS = 0.007;
+
+// [latitude, longitude]. Spread across continents so arcs cross the disc
+// rather than huddling in one hemisphere.
+const CITIES: Array<[number, number]> = [
+	[41.01, 28.98], // Istanbul
+	[52.52, 13.41], // Berlin
+	[48.86, 2.35], // Paris
+	[40.42, -3.7], // Madrid
+	[51.51, -0.13], // London
+	[40.71, -74.01], // New York
+	[19.43, -99.13], // Mexico City
+	[-23.55, -46.63], // São Paulo
+	[-34.6, -58.38], // Buenos Aires
+	[6.52, 3.38], // Lagos
+	[30.04, 31.24], // Cairo
+	[-1.29, 36.82], // Nairobi
+	[19.08, 72.88], // Mumbai
+	[-6.21, 106.85], // Jakarta
+	[37.57, 126.98], // Seoul
+	[35.68, 139.69], // Tokyo
+	[-33.87, 151.21], // Sydney
+	[55.76, 37.62], // Moscow
+	[35.69, 51.39], // Tehran
+	[43.65, -79.38] // Toronto
+];
+
+function toVector(lat: number, lon: number, r: number): Vector3 {
+	const phi = MathUtils.degToRad(90 - lat);
+	const theta = MathUtils.degToRad(lon + 180);
+	return new Vector3(
+		-r * Math.sin(phi) * Math.cos(theta),
+		r * Math.cos(phi),
+		r * Math.sin(phi) * Math.sin(theta)
+	);
+}
+
+function arcBetween(a: Vector3, b: Vector3): CubicBezierCurve3 {
+	// Longer hops rise higher, so a Tokyo–São Paulo arc clears the disc.
+	const lift = RADIUS * (0.12 + a.distanceTo(b) * 0.25);
+	const c1 = a
+		.clone()
+		.lerp(b, 0.25)
+		.normalize()
+		.multiplyScalar(RADIUS + lift);
+	const c2 = a
+		.clone()
+		.lerp(b, 0.75)
+		.normalize()
+		.multiplyScalar(RADIUS + lift);
+	return new CubicBezierCurve3(a, c1, c2, b);
+}
+
+function fibonacciSphere(count: number, r: number): Float32Array {
+	const out = new Float32Array(count * 3);
+	const golden = Math.PI * (3 - Math.sqrt(5));
+	for (let i = 0; i < count; i++) {
+		const y = 1 - (i / (count - 1)) * 2;
+		const ring = Math.sqrt(1 - y * y);
+		const theta = golden * i;
+		out[i * 3] = Math.cos(theta) * ring * r;
+		out[i * 3 + 1] = y * r;
+		out[i * 3 + 2] = Math.sin(theta) * ring * r;
+	}
+	return out;
+}
+
+// Points render as squares by default; a soft disc texture makes them dots.
+function discTexture(): Texture {
+	const size = 32;
+	const canvas = document.createElement('canvas');
+	canvas.width = canvas.height = size;
+	const ctx = canvas.getContext('2d');
+	if (ctx) {
+		ctx.fillStyle = '#fff';
+		ctx.beginPath();
+		ctx.arc(size / 2, size / 2, size / 2 - 1, 0, Math.PI * 2);
+		ctx.fill();
+	}
+	const texture = new Texture(canvas);
+	texture.needsUpdate = true;
+	return texture;
+}
+
+function smoothstep(p: number): number {
+	return p * p * (3 - 2 * p);
+}
+
+interface Arc {
+	curve: CubicBezierCurve3;
+	material: MeshBasicMaterial;
+	tube: Mesh<TubeGeometry, MeshBasicMaterial>;
+	head: Mesh<SphereGeometry, MeshBasicMaterial>;
+	phase: 'grow' | 'hold' | 'fade';
+	t: number;
+}
+
+export function createGlobe(container: HTMLElement, options: GlobeOptions): GlobeHandle {
+	// Throws when the browser has no WebGL; the component hides itself then.
+	const renderer = new WebGLRenderer({ antialias: true, alpha: true });
+	renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2));
+	renderer.setClearColor(0x000000, 0);
+	container.appendChild(renderer.domElement);
+
+	const scene = new Scene();
+	const camera = new PerspectiveCamera(30, 1, 0.1, 20);
+	camera.position.set(0, 0.35, 4.8);
+	camera.lookAt(0, 0, 0);
+
+	const tilt = new Group();
+	tilt.rotation.z = -TILT;
+	const spin = new Group();
+	tilt.add(spin);
+	scene.add(tilt);
+
+	const disc = discTexture();
+
+	const surfaceMaterial = new MeshBasicMaterial({ color: options.colors.surface });
+	const surface = new Mesh(new SphereGeometry(RADIUS, 48, 48), surfaceMaterial);
+	spin.add(surface);
+
+	const dotsGeometry = new BufferGeometry();
+	dotsGeometry.setAttribute(
+		'position',
+		new Float32BufferAttribute(fibonacciSphere(DOT_COUNT, RADIUS * 1.004), 3)
+	);
+	const dotsMaterial = new PointsMaterial({
+		color: options.colors.dots,
+		size: 2.5,
+		sizeAttenuation: false,
+		map: disc,
+		alphaTest: 0.5,
+		transparent: true,
+		opacity: 0.8
+	});
+	spin.add(new Points(dotsGeometry, dotsMaterial));
+
+	const cityVectors = CITIES.map(([lat, lon]) => toVector(lat, lon, RADIUS * 1.01));
+	const cityGeometry = new BufferGeometry().setFromPoints(cityVectors);
+	const cityMaterial = new PointsMaterial({
+		color: options.colors.city,
+		size: 7,
+		sizeAttenuation: false,
+		map: disc,
+		alphaTest: 0.5
+	});
+	spin.add(new Points(cityGeometry, cityMaterial));
+
+	const headGeometry = new SphereGeometry(0.018, 12, 12);
+	const arcs: Arc[] = [];
+
+	function pickPair(): [Vector3, Vector3] {
+		const a = Math.floor(Math.random() * cityVectors.length);
+		let b = a;
+		// Skip neighbours: a Berlin–Paris arc is too short to read as travel.
+		while (b === a || cityVectors[a].distanceTo(cityVectors[b]) < 0.5) {
+			b = Math.floor(Math.random() * cityVectors.length);
+		}
+		return [cityVectors[a], cityVectors[b]];
+	}
+
+	function restart(arc: Arc, delay: number) {
+		const [a, b] = pickPair();
+		arc.curve = arcBetween(a, b);
+		arc.tube.geometry.dispose();
+		arc.tube.geometry = new TubeGeometry(arc.curve, TUBE_SEGMENTS, TUBE_RADIUS, TUBE_RADIAL, false);
+		arc.tube.geometry.setDrawRange(0, 0);
+		arc.head.visible = false;
+		arc.material.opacity = 1;
+		arc.phase = 'grow';
+		arc.t = -delay;
+	}
+
+	function draw(arc: Arc, progress: number) {
+		const eased = smoothstep(progress);
+		arc.tube.geometry.setDrawRange(0, Math.floor(eased * TUBE_SEGMENTS) * TUBE_RADIAL * 6);
+		arc.head.position.copy(arc.curve.getPoint(eased));
+		arc.head.visible = true;
+	}
+
+	for (let i = 0; i < ARC_COUNT; i++) {
+		const material = new MeshBasicMaterial({ color: options.colors.arc, transparent: true });
+		const tube = new Mesh(new TubeGeometry(), material);
+		const head = new Mesh(headGeometry, material);
+		spin.add(tube, head);
+		const arc: Arc = {
+			curve: arcBetween(cityVectors[0], cityVectors[1]),
+			material,
+			tube,
+			head,
+			phase: 'grow',
+			t: 0
+		};
+		arcs.push(arc);
+		// Staggered starts, so the four arcs never move in lockstep.
+		restart(arc, options.animate ? i * 0.6 : 0);
+		if (!options.animate) draw(arc, 1);
+	}
+
+	function step(dt: number) {
+		for (const arc of arcs) {
+			arc.t += dt;
+			if (arc.phase === 'grow') {
+				if (arc.t < 0) continue;
+				const p = Math.min(arc.t / GROW, 1);
+				draw(arc, p);
+				if (p === 1) {
+					arc.phase = 'hold';
+					arc.t = 0;
+				}
+			} else if (arc.phase === 'hold') {
+				if (arc.t >= HOLD) {
+					arc.phase = 'fade';
+					arc.t = 0;
+				}
+			} else {
+				arc.material.opacity = Math.max(1 - arc.t / FADE, 0);
+				if (arc.t >= FADE) restart(arc, Math.random() * 0.8);
+			}
+		}
+	}
+
+	function render() {
+		renderer.render(scene, camera);
+	}
+
+	// Mouse and pen can drag the globe; touch is left alone so the page
+	// still scrolls when a thumb lands on the hero.
+	let dragging = false;
+	let lastX = 0;
+	let lastY = 0;
+	const canvas = renderer.domElement;
+	canvas.style.cursor = 'grab';
+	const onDown = (e: PointerEvent) => {
+		if (e.pointerType === 'touch') return;
+		dragging = true;
+		lastX = e.clientX;
+		lastY = e.clientY;
+		canvas.setPointerCapture(e.pointerId);
+		canvas.style.cursor = 'grabbing';
+	};
+	const onMove = (e: PointerEvent) => {
+		if (!dragging) return;
+		spin.rotation.y += (e.clientX - lastX) * 0.005;
+		spin.rotation.x = MathUtils.clamp(spin.rotation.x + (e.clientY - lastY) * 0.005, -0.6, 0.6);
+		lastX = e.clientX;
+		lastY = e.clientY;
+		if (!running) render();
+	};
+	const onUp = () => {
+		dragging = false;
+		canvas.style.cursor = 'grab';
+	};
+	canvas.addEventListener('pointerdown', onDown);
+	canvas.addEventListener('pointermove', onMove);
+	canvas.addEventListener('pointerup', onUp);
+	canvas.addEventListener('pointercancel', onUp);
+
+	const clock = new Clock(false);
+	let raf = 0;
+	let running = false;
+	let paused = false;
+
+	function frame() {
+		raf = requestAnimationFrame(frame);
+		// Cap the step so a tab that was asleep does not lurch when it wakes.
+		const dt = Math.min(clock.getDelta(), 0.05);
+		if (!dragging) spin.rotation.y += dt * SPIN;
+		step(dt);
+		render();
+	}
+
+	function start() {
+		if (running || !options.animate) return;
+		running = true;
+		clock.start();
+		frame();
+	}
+
+	function stop() {
+		if (!running) return;
+		running = false;
+		cancelAnimationFrame(raf);
+		clock.stop();
+	}
+
+	function resize() {
+		const size = container.clientWidth;
+		if (!size) return;
+		renderer.setSize(size, size, false);
+		render();
+	}
+	const observer = new ResizeObserver(resize);
+	observer.observe(container);
+	resize();
+	if (!paused) start();
+
+	return {
+		setColors(colors) {
+			surfaceMaterial.color.set(colors.surface);
+			dotsMaterial.color.set(colors.dots);
+			cityMaterial.color.set(colors.city);
+			for (const arc of arcs) arc.material.color.set(colors.arc);
+			if (!running) render();
+		},
+		setPaused(next) {
+			paused = next;
+			if (paused) stop();
+			else start();
+		},
+		destroy() {
+			stop();
+			observer.disconnect();
+			canvas.removeEventListener('pointerdown', onDown);
+			canvas.removeEventListener('pointermove', onMove);
+			canvas.removeEventListener('pointerup', onUp);
+			canvas.removeEventListener('pointercancel', onUp);
+			surface.geometry.dispose();
+			surfaceMaterial.dispose();
+			dotsGeometry.dispose();
+			dotsMaterial.dispose();
+			cityGeometry.dispose();
+			cityMaterial.dispose();
+			headGeometry.dispose();
+			disc.dispose();
+			for (const arc of arcs) {
+				arc.tube.geometry.dispose();
+				arc.material.dispose();
+			}
+			renderer.dispose();
+			canvas.remove();
+		}
+	};
+}

--- a/src/lib/components/organisms/Hero.svelte
+++ b/src/lib/components/organisms/Hero.svelte
@@ -1,16 +1,13 @@
 <script lang="ts">
 	import Button from '$lib/components/atoms/Button.svelte';
-	import PhoneFrame from '$lib/components/phone/PhoneFrame.svelte';
-	import ChatScreen from '$lib/components/phone/ChatScreen.svelte';
+	import Globe from '$lib/components/globe/Globe.svelte';
 	import { ownsPrimary } from '$lib/stores/cta';
 </script>
 
-<!-- The app on the left doing its thing, the ask on the right. Two buttons, nothing else. -->
+<!-- The world on the left, the ask on the right. Two buttons, nothing else. -->
 <section id="hero" class="hero">
 	<div class="device">
-		<PhoneFrame label="A LangX chat: two messages in Spanish, then a friendly correction">
-			<ChatScreen loop />
-		</PhoneFrame>
+		<Globe label="A globe with arcs linking cities where people are chatting on LangX" />
 	</div>
 
 	<div class="copy">
@@ -48,21 +45,13 @@
 	}
 
 	.device {
-		--phone-zoom: 0.78;
 		display: flex;
 		justify-content: center;
 
-		@media (max-width: 1100px) {
-			--phone-zoom: 0.7;
-		}
-
 		@include for-tablet-portrait-down {
 			order: 2;
-			--phone-zoom: 0.72;
-		}
-
-		@include for-phone-only {
-			--phone-zoom: 0.66;
+			max-width: 360px;
+			margin: 0 auto;
 		}
 	}
 


### PR DESCRIPTION
A Three.js globe replaces the phone in the homepage hero: a dotted sphere, twenty cities, six arcs that grow between them, rest, fade and start again.

- `three` is imported after mount from its own chunk (129 KB gzipped), homepage only; the prerendered HTML does not reference it.
- Colours come from the theme tokens, so the light/dark toggle recolours the globe live.
- Rendering pauses off-screen and in hidden tabs; reduced motion gets one still frame with every arc complete.
- Mouse/pen drag rotates it; touch is left to page scrolling.
- No WebGL: the component hides itself and the hero shows the copy alone.

`ChatScreen.svelte` no longer has a user and is left in place.

Verified in the dev server in both themes and at phone width; `npm run check`, `npm run lint` and `npx vite build` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)