### PR TITLE
Show the plans and welcome-back cards on pages that ship no JS

### DIFF
--- a/src/lib/components/organisms/PlanCards.svelte
+++ b/src/lib/components/organisms/PlanCards.svelte
@@ -4,7 +4,8 @@
 
 	/**
 	 * `detailed` is the plans page: the notes under each point are shown, and
-	 * the section title is left to the page header above.
+	 * the section title is left to the page header above. That page ships no
+	 * JS (csr = dev), so nothing on it may start hidden for a reveal.
 	 */
 	export let detailed = false;
 </script>
@@ -19,7 +20,11 @@
 		</header>
 	{/if}
 
-	<div class="grid" data-reveal-children use:reveal={{ children: true, stagger: 0.1 }}>
+	<div
+		class="grid"
+		data-reveal-children={detailed ? undefined : true}
+		use:reveal={{ children: true, stagger: 0.1 }}
+	>
 		{#each plans as plan}
 			<article class="card {plan.tone ?? 'free'}">
 				<div class="name">

--- a/src/lib/components/organisms/PlanUsageCard.svelte
+++ b/src/lib/components/organisms/PlanUsageCard.svelte
@@ -1,18 +1,15 @@
 <script lang="ts">
-	import { reveal } from '$lib/utils/reveal';
-
 	// What a Fluent day looks like inside the app. The 300 is Fluent's
 	// translation cap in `data/plans.ts`; the 12 is a morning's use.
 	const used = 12;
 	const cap = 300;
 </script>
 
+<!-- No reveal: /pro ships no JS (csr = dev), so a hidden card would stay hidden. -->
 <div
 	class="card"
 	role="img"
 	aria-label="A Fluent account's day: unlimited chats, 12 of 300 translations used, two languages each way"
-	data-reveal
-	use:reveal={{ y: 40 }}
 >
 	<div class="head">
 		<span class="plan">Fluent</span>

--- a/src/lib/components/organisms/RestoreCard.svelte
+++ b/src/lib/components/organisms/RestoreCard.svelte
@@ -1,17 +1,15 @@
 <script lang="ts">
 	import { legacyTokenDivisor, welcomeBackBonus } from '$lib/data/token';
-	import { reveal } from '$lib/utils/reveal';
 
 	/** What a returning v1 user sees. The 20 carried-over tokens are a demo balance. */
 	const carried = 20;
 </script>
 
+<!-- No reveal: /welcome-back ships no JS (csr = dev), so a hidden card would stay hidden. -->
 <div
 	class="card"
 	role="img"
 	aria-label="The welcome-back screen: your handle, imported conversations, converted tokens and a frozen streak"
-	data-reveal
-	use:reveal={{ y: 40 }}
 >
 	<div class="hello">
 		<span class="wave" aria-hidden="true">👋</span>


### PR DESCRIPTION
Regression from #147: `/pro` and `/welcome-back` export `csr = dev`, so production ships no JS there. The two new cards started hidden for a scroll reveal and nothing ever showed them; the dev server (which does ship JS) hid the bug.

Fix: no reveal on those two cards; the plan cards only start hidden on the homepage. Verified on the prerendered output: `data-reveal` count is 0 in `pro.html` and `welcome-back.html`, 14 on the homepage as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)