### PR TITLE
Two Polyglot features the pricing page never listed

### DIFF
--- a/src/lib/data/plans.ts
+++ b/src/lib/data/plans.ts
@@ -67,11 +67,19 @@ export const plans: Plan[] = [
 		points: [
 			{ label: 'See who viewed your profile' },
 			{ label: 'Incognito browsing' },
+			{
+				label: 'Write in your language, send in theirs',
+				note: 'Reading a translation is free on every plan. This is the other direction — your own message goes with a translation under it.'
+			},
 			{ label: '1000 translations a day' },
 			{ label: '5 languages you are learning, 5 you speak natively' },
 			{
 				label: 'Nearby',
 				note: 'Sorts discovery by distance, if you turn location sharing on.'
+			},
+			{
+				label: 'Export your saved phrases',
+				note: 'A conversation’s saved phrases as a file. It opens in Anki.'
 			},
 			{
 				label: 'LangX Copilot',


### PR DESCRIPTION
`sendTranslation` and `deckExport` both shipped to Polyglot in langx/langx#1209 and langx/langx#1212 and neither reached this file, so the page understated the top plan.

Sending is worth a note: the obvious misreading is that translation itself went behind a paywall, when reading a received message is free on every plan and untouched at 20 a day. The label says which direction is paid and the note says the other one is not.
🤖 Generated with [Claude Code](https://claude.com/claude-code)