### PR TITLE
Send readers on to token.langx.io for the detail

### DIFF
--- a/src/lib/components/organisms/FAQ.svelte
+++ b/src/lib/components/organisms/FAQ.svelte
@@ -28,7 +28,7 @@
 		{
 			id: 4,
 			title: 'What is LangX Token?',
-			content: `Points you earn by chatting and by correcting other people. You spend them inside the app on a streak freeze or on frames and titles for your profile. They aren't money: you can't buy, sell or trade them, and they never unlock a paid plan.`
+			content: `Points you earn by chatting and by correcting other people. You spend them inside the app on a streak freeze or on frames and titles for your profile. They aren't money: you can't buy, sell or trade them, and they never unlock a paid plan. <a href="/tokens">Every rule is on the tokens page</a>, and the longer write-up is at <a href="https://token.langx.io" target="_blank" rel="noopener noreferrer">token.langx.io</a>.`
 		},
 		{
 			id: 5,

--- a/src/lib/components/organisms/Footer.svelte
+++ b/src/lib/components/organisms/Footer.svelte
@@ -16,6 +16,7 @@
 			links: [
 				{ label: 'Plans', href: '/pro' },
 				{ label: 'Tokens', href: '/tokens' },
+				{ label: 'LangX Token', href: 'https://token.langx.io' },
 				{ label: 'Coming from v1?', href: '/welcome-back' },
 				{ label: 'Web app', href: 'https://app.langx.io' },
 				{ label: 'iOS', href: 'https://apps.apple.com/app/languagexchange/id6474187141' },

--- a/src/lib/components/organisms/Tokens.svelte
+++ b/src/lib/components/organisms/Tokens.svelte
@@ -126,6 +126,17 @@
 		</article>
 
 		<article class="block">
+			<h2>Where the longer version lives</h2>
+			<p>
+				This page is the rules as the app enforces them, mirrored from its source so they cannot
+				drift apart. The model itself — where it came from, what it is for, and the reasoning behind
+				it — is written up at
+				<a href="https://token.langx.io" target="_blank" rel="noopener noreferrer">token.langx.io</a
+				>.
+			</p>
+		</article>
+
+		<article class="block">
 			<h2>These are starting values</h2>
 			<p>
 				Every number here is marked as a starting value in the app's own source, and is expected to


### PR DESCRIPTION
Follow-up to #152, which repointed the footer's "LangX Token" entry at the new `/tokens` page and so took the external site out of the site's own navigation.

It goes back — **beside** the new page rather than instead of it:

- `Tokens` → `/tokens` — the rules as the app enforces them, mirrored from `token.ts`
- `LangX Token` → `token.langx.io` — the longer write-up

`/tokens` closes with the same pointer ("Where the longer version lives"), and the homepage's **"What is LangX Token?"** FAQ answer now goes both ways: to the rules page, and out to the write-up. Both external links open in a new tab.

## Docs needed nothing

Every external link in the footer already renders `target="_blank" rel="noopener noreferrer"` through its `isExternal` helper, and the footer is the only place `docs.langx.io` is linked from. Verified against the served HTML rather than the source:

```
$ curl -s / | grep -o '<a[^>]*docs\.langx\.io[^>]*>'
<a href="https://docs.langx.io" target="_blank" rel="noopener noreferrer" …>
```

If you meant a Docs link somewhere else — the header, say, which currently carries Features / Plans / FAQ / GitHub — that is a different change and I have not made it.

## Checks

`prettier` and `eslint` clean; `svelte-check` 0 errors, 3 pre-existing `text-wrap` warnings; build writes `build/`. All three new links confirmed carrying `target="_blank" rel="noopener noreferrer"` in the built HTML, on both `index.html` and `tokens.html`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
