### PR TITLE
A message earns 1 token, not 2

### DIFF
--- a/src/lib/data/token.ts
+++ b/src/lib/data/token.ts
@@ -8,7 +8,7 @@
  */
 
 export const tokenEarning = [
-	{ action: 'Send a message', amount: '2' },
+	{ action: 'Send a message', amount: '1' },
 	{ action: "Correct someone else's sentence", amount: '10' },
 	{ action: 'Answer a pronunciation request with a recording', amount: '10' },
 	{ action: 'First conversation where both of you have spoken', amount: '15' }


### PR DESCRIPTION
`TOKEN_RULES` moved upstream. `token.ts` mirrors it, and it is the only place on the site that states a rate — the homepage token section and `/tokens` both read `tokenEarning` from there, so this one line carries both:

```
- { action: 'Send a message', amount: '2' },
+ { action: 'Send a message', amount: '1' },
```

Confirmed rendering as `1` on `/` and `/tokens`.

## One thing to check upstream

`tokenCaps` still says **"Up to 100 tokens a day from messages"** and **"At most 30 of those from any one person"**. Those are separate `TOKEN_RULES` values, so I have not touched them — but halving the per-message rate doubles what they allow in practice: the daily ceiling is now 100 messages rather than 50, and the per-person one 30 rather than 15. If either moved alongside the rate, say so and I will mirror them too.

## Checks

`prettier` and `eslint` clean; `svelte-check` 0 errors, 3 pre-existing `text-wrap` warnings; build writes `build/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
