### PR TITLE
Offer the write-up before the rules, not after them

### DIFF
--- a/src/lib/components/organisms/Tokens.svelte
+++ b/src/lib/components/organisms/Tokens.svelte
@@ -126,11 +126,11 @@
 		</article>
 
 		<article class="block">
-			<h2>Where the longer version lives</h2>
+			<h2>Where these numbers come from</h2>
 			<p>
-				This page is the rules as the app enforces them, mirrored from its source so they cannot
-				drift apart. The model itself — where it came from, what it is for, and the reasoning behind
-				it — is written up at
+				Every rate and ceiling above is mirrored from the app's own source, so the page and the app
+				cannot drift apart. Everything that is not a rule — the model, its history, the reasoning —
+				lives at
 				<a href="https://token.langx.io" target="_blank" rel="noopener noreferrer">token.langx.io</a
 				>.
 			</p>

--- a/src/routes/tokens/+page.svelte
+++ b/src/routes/tokens/+page.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+	import Button from '$lib/components/atoms/Button.svelte';
+	import UiIcon from '$lib/components/atoms/UiIcon.svelte';
 	import PageHeader from '$lib/components/organisms/PageHeader.svelte';
 	import Tokens from '$lib/components/organisms/Tokens.svelte';
 </script>
@@ -9,5 +11,47 @@
 		title="A point you earn by helping somebody"
 		lede="Tokens are in-app points, earned by practising and teaching and spent on a streak freeze, a missed day or something cosmetic. They cannot be bought, sold, traded or withdrawn, and there is no chain behind them. Here is every rule, including the ceilings."
 	/>
+
+	<!--
+		The write-up is offered before the rules, not after them: somebody who
+		came here for the model should not have to read a page of ceilings first.
+	-->
+	<div class="promo">
+		<p>
+			The model itself — where it came from, what it is for, and the thinking behind it — is written
+			up in full on its own site.
+		</p>
+		<Button href="https://token.langx.io" variant="secondary" size="lg">
+			Open token.langx.io
+			<UiIcon slot="icon" name="external" size={18} />
+		</Button>
+	</div>
+
 	<Tokens />
 </div>
+
+<style lang="scss">
+	@import '$lib/scss/breakpoints.scss';
+
+	.promo {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		flex-wrap: wrap;
+		gap: var(--space-sm) var(--space-lg);
+		padding: 0 0 var(--space-lg);
+
+		p {
+			margin: 0;
+			max-width: 52ch;
+			font-size: 1rem;
+			line-height: 1.6;
+			color: var(--color--text-shade);
+		}
+
+		@include for-phone-only {
+			align-items: flex-start;
+			flex-direction: column;
+		}
+	}
+</style>


### PR DESCRIPTION
`/tokens` already carried a `token.langx.io` link, but in a closing block — so anybody who came for the model had a page of rates and ceilings to get through first.

**The link moves to the top**, directly under the lede: one sentence saying what is over there, and the button beside it. It is now the first action on the page, before any rule.

```
PageHeader
→ "The model itself … is written up in full on its own site."  [Open token.langx.io]
A token is a point, and that is all
How you earn them
…
```

**The closing block stays but stops repeating the pitch.** It now says the thing the top cannot — that every rate above is mirrored from the app's own source, so the page and the app cannot drift apart — and carries the link on the way out. A reader who goes end to end no longer meets the same sentence twice.

## Why it is secondary and not yellow

Yellow is the site's commit-to-LangX colour, and this page already spends it on the app CTA at the bottom. A link off the site is not that action, however much it wants promoting — so it takes the strongest thing that is not yellow, matching the button in the homepage's token section so the two read as the same offer.

## Checks

`prettier` and `eslint` clean; `svelte-check` 0 errors, 3 pre-existing `text-wrap` warnings; build writes `build/`. Rendered at 1280 and 430 wide — the row stacks to sentence-over-button on a phone. Source order confirmed: the button precedes the first rule block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
