### PR TITLE
Stop the token.langx.io button drifting off to the right

### DIFF
--- a/src/routes/tokens/+page.svelte
+++ b/src/routes/tokens/+page.svelte
@@ -33,12 +33,14 @@
 <style lang="scss">
 	@import '$lib/scss/breakpoints.scss';
 
+	// Stacked and left-aligned, not a full-width row: the rules below sit in a
+	// 1.2fr column, so a button pushed to the container's right edge lands over
+	// the phone and reads as belonging to neither.
 	.promo {
 		display: flex;
-		align-items: center;
-		justify-content: space-between;
-		flex-wrap: wrap;
-		gap: var(--space-sm) var(--space-lg);
+		flex-direction: column;
+		align-items: flex-start;
+		gap: var(--space-sm);
 		padding: 0 0 var(--space-lg);
 
 		p {
@@ -47,11 +49,6 @@
 			font-size: 1rem;
 			line-height: 1.6;
 			color: var(--color--text-shade);
-		}
-
-		@include for-phone-only {
-			align-items: flex-start;
-			flex-direction: column;
 		}
 	}
 </style>


### PR DESCRIPTION
Reported against #156.

The promo row under the header was a full-width flex with `space-between`, so on a desktop the button was pushed to the container's right edge. Everything below it sits in a `1.2fr / 0.8fr` grid, so the button landed **above the phone column** — reading as belonging neither to the sentence it came with nor to the screen it hovered over.

Stacked and left-aligned instead. Measured after the fix, every element on the page now shares one left edge:

```
h1            130
lede          130
promo text    130
promo button  130
first rule    130
```

The phone-width rendering is unchanged — it was already stacking.

## Checks

`prettier` and `eslint` clean; `svelte-check` 0 errors, 3 pre-existing `text-wrap` warnings; build writes `build/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
