### PR TITLE
Mirror the caps that moved with the message rate

### DIFF
--- a/src/lib/data/token.ts
+++ b/src/lib/data/token.ts
@@ -15,8 +15,8 @@ export const tokenEarning = [
 ];
 
 export const tokenCaps = [
-	'Up to 100 tokens a day from messages.',
-	'At most 30 of those from any one person, so talking to a single partner all day is not a strategy.',
+	'Up to 200 tokens a day from messages.',
+	'At most 60 of those from any one person, so it takes four partners to reach the ceiling and talking to one all day is not a strategy.',
 	'A shared daily pool of 10,000 tokens is split between that day’s active users, in proportion to how active they were. No one can take more than 5% of it.'
 ];
 
@@ -46,7 +46,7 @@ export const tokenSinks = [
 		name: 'Frames and titles',
 		price: '1,000 – 100,000 tokens',
 		description:
-			'Cosmetic only: ten avatar frames from Slate to Midnight, and ten titles from Beginner to Legend.'
+			'Cosmetic only: ten avatar frames from Slate to Aurora, and ten titles from Beginner to Legend.'
 	}
 ];
 

--- a/src/routes/tokens/+page.svelte
+++ b/src/routes/tokens/+page.svelte
@@ -9,7 +9,7 @@
 	<PageHeader
 		eyebrow="Tokens"
 		title="A point you earn by helping somebody"
-		lede="Tokens are in-app points, earned by practising and teaching and spent on a streak freeze, a missed day or something cosmetic. They cannot be bought, sold, traded or withdrawn, and there is no chain behind them. Here is every rule, including the ceilings."
+		lede="Tokens are in-app points, earned by practising and teaching and spent on a streak freeze, a missed day or something cosmetic. They cannot be bought, sold, traded or withdrawn, and there is no chain behind them. Here is how they are earned, capped and spent."
 	/>
 
 	<!--


### PR DESCRIPTION
Checked against `TOKEN_RULES` in `langx/packages/shared/src/token.ts` at `origin/main` (local checkout 0 commits behind), rather than inferred from the rate change.

## Corrected

| Field | Site said | Source says |
| --- | --- | --- |
| `caps.messagesPerDay` | 100 | **200** |
| `caps.messagesPerPartnerPerDay` | 30 | **60** |
| tenth frame | Midnight | **Aurora** |

The source explains the first two in a comment, and the reason is worth keeping: the cap is on *token earned*, not on messages sent. Halving `award.message` without doubling the count would have silently repriced the whole shop — a freeze is meant to cost a day, a repair three. The per-partner number moved with it to hold the 200/60 ratio that 100/30 had, which is what keeps four partners the price of a full day.

Midnight is the ninth frame. Aurora is the tenth, and it cannot be bought at any balance: it needs a 365-day streak *and* 5,000 corrections written.

## Checked and already correct

All four earning rates · all seven streak milestones · the 10,000 pool and its 5% share cap · streak freeze 200 with two banked · day repair 600, within 14 days, twice a month · the hourly gift at once an hour and 0–250, including the "about a third empty, nine in ten under 30" shape · `legacyTokenDivisor` 100 · `welcomeBackBonus` 250.

## Two rules the site does not carry at all

Both are live in the app — `apps/api/src/modules/referrals/` and `apps/mobile/app/(app)/invite.tsx`:

- **`signupBonus: 250`** — a new account starts with a balance.
- **`referral`** — activation 1000, subscription 4000, invitee 750 / 1000, capped at 5000 per invitee.

So the `/tokens` lede claiming *"Here is every rule, including the ceilings"* was not true. It now says **"Here is how they are earned, capped and spent."** Adding the two sections is a content call — say the word and I will.

## One upstream disagreement, not fixed here

`docs/token-messaging-brief.md` says filling in a missed day costs **300 tokens**; `TOKEN_RULES.sinks.dayRepair` says **600**. The site mirrors `TOKEN_RULES`, because that is what the app enforces — but one of those two documents is stale on your side.

## Checks

`prettier` and `eslint` clean; `svelte-check` 0 errors, 3 pre-existing `text-wrap` warnings; build writes `build/`, and all three corrected strings confirmed in `build/tokens.html`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
