### PR TITLE
Sticker packs are the fourth thing tokens buy

### DIFF
--- a/src/lib/data/token.ts
+++ b/src/lib/data/token.ts
@@ -47,6 +47,12 @@ export const tokenSinks = [
 		price: '1,000 – 100,000 tokens',
 		description:
 			'Cosmetic only: ten avatar frames from Slate to Aurora, and ten titles from Beginner to Legend.'
+	},
+	{
+		name: 'Sticker packs',
+		price: '1,000 tokens each',
+		description:
+			'Two packs of twelve stickers to send in a chat. Both cost the same — one pack is never a rung above another — and none of them carry lettering, because the app is read in eight languages.'
 	}
 ];
 

--- a/src/routes/(blog-article)/langx-v2-what-changes-and-why/+page.md
+++ b/src/routes/(blog-article)/langx-v2-what-changes-and-why/+page.md
@@ -88,11 +88,11 @@ describing something tradable, staked and eventually listed on an exchange.
 **The name stays. The trading does not.**
 
 LangX Token in v2 is an in-app point. You earn it by practising and by teaching
-— correcting someone else's sentence is worth five times sending a message —
-and you spend it on a streak freeze or on cosmetic frames and titles. That is
-the complete list of things to spend it on, and it is complete on purpose: if
-tokens could buy a Pro feature, farming tokens would become a substitute for
-subscribing.
+— correcting someone else's sentence is worth ten times sending a message — and
+you spend it on your streak or on cosmetics: a freeze, a filled-in day, frames,
+titles and sticker packs. That is the complete list of things to spend it on,
+and it is complete on purpose: if tokens could buy a Pro feature, farming
+tokens would become a substitute for subscribing.
 
 It cannot be bought, sold, traded, staked, transferred or withdrawn, and it is
 not on a blockchain. **The on-chain design in the old litepaper is not being


### PR DESCRIPTION
`COSMETICS` gained two sticker packs at 1,000 tokens each, so `tokenSinks` was
a sink short. The token page renders that list, so nothing else on it changed.

The v2 launch article carried two claims that stopped being true along the way:

- "correcting someone else's sentence is worth **five** times sending a
  message" — it is ten now, since `award.message` went from 2 to 1.
- its list of what tokens buy predates both the day repair and the packs.

An article can be dated. A wrong number about the product that ships today is a
different thing, so both are corrected in place.

Verified with `npx vite build`; the sticker row and the corrected sentence are
both in the prerendered HTML.

🤖 Generated with [Claude Code](https://claude.com/claude-code)