### PR TITLE
Count page views, and store nothing on the visitor to do it

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,6 +26,13 @@ jobs:
       - name: build
         env:
           BASE_PATH: '/${{ github.event.repository.name }}'
+          # A repository *variable*, not a secret, and deliberately so: Vite
+          # inlines this into the bundle every visitor downloads, so calling it
+          # a secret would only be theatre. A PostHog project API key can write
+          # events and never read them, and this is literally the app's
+          # EXPO_PUBLIC_POSTHOG_KEY — one project, because the free plan allows
+          # one. Unset, the SDK is never loaded and the site sends nothing.
+          VITE_POSTHOG_KEY: ${{ vars.VITE_POSTHOG_KEY }}
         run: |
           npm run build
 

--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -39,7 +39,11 @@ source (BSD-3) and self-hostable. No ads and no advertising identifiers. There *
 third-party analytics SDK — PostHog, on its EU cloud, screen names and a short
 list of events keyed by the LangX user id, no session recording, off in
 Settings → Privacy. It arrived after this file was written and after the
-privacy policy said there was none; both have been corrected. Any claim about
+privacy policy said there was none; both have been corrected. **This site has
+analytics too**, since September 2026: the same PostHog, in cookieless mode, so
+it writes nothing to the visitor's browser and there is still no cookie banner.
+A "no trackers" line is false on both, but "nothing is stored on your device" is
+true of the site. Any claim about
 tracking on a new page has to be checked against
 `langx/docs/store/privacy-data-safety.md`, which is written from the code. "Open source alternative to Tandem" is an existing,
 published line.

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
 				"@fontsource/nunito": "^5.3.0",
 				"@types/three": "^0.185.4",
 				"gsap": "^3.15.0",
+				"posthog-js": "^1.428.6",
 				"three": "^0.185.1"
 			},
 			"devDependencies": {
@@ -692,6 +693,31 @@
 			"integrity": "sha512-2LuNTFBIO0m7kKIQvvPHN6UE63VjpmL9rnEEaOOaiSPbZK+zUOYIzBAWcED+3XYzhYsd/0mD57VdxAEqqV52CQ==",
 			"dev": true
 		},
+		"node_modules/@posthog/browser-common": {
+			"version": "0.8.2",
+			"resolved": "https://registry.npmjs.org/@posthog/browser-common/-/browser-common-0.8.2.tgz",
+			"integrity": "sha512-8g7+ijrx8bfWmpDjmP07e0ZmdRnJoFqZ6PCcMQvfBTUrr422GRXvQWpQn7yD028zIJHIIn/rUTipKgUC5UkWpw==",
+			"license": "MIT",
+			"dependencies": {
+				"@posthog/core": "^1.51.0",
+				"@posthog/types": "^1.409.1"
+			}
+		},
+		"node_modules/@posthog/core": {
+			"version": "1.51.0",
+			"resolved": "https://registry.npmjs.org/@posthog/core/-/core-1.51.0.tgz",
+			"integrity": "sha512-LilmmtjcrjV1LgaVNQXrAUt4IXcWIYMrwEtx6VJUUFDeBBdmeI99jshKGtAWugYeB3Wkcp9xQIVCrxIYRpNiRA==",
+			"license": "MIT",
+			"dependencies": {
+				"@posthog/types": "^1.409.1"
+			}
+		},
+		"node_modules/@posthog/types": {
+			"version": "1.409.2",
+			"resolved": "https://registry.npmjs.org/@posthog/types/-/types-1.409.2.tgz",
+			"integrity": "sha512-hZ4EXZ1+BstMaxUkmAEg3qvgMR/S00Xb+wEwY/Tx2Dr9dBgiBWrERxaq2UwICh/Fh/vVXpKZT/0SkRtO8JKQ2A==",
+			"license": "MIT"
+		},
 		"node_modules/@sinclair/typebox": {
 			"version": "0.27.8",
 			"resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
@@ -878,6 +904,13 @@
 				"fflate": "~0.8.2",
 				"meshoptimizer": "~1.1.1"
 			}
+		},
+		"node_modules/@types/trusted-types": {
+			"version": "2.0.7",
+			"resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+			"integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+			"license": "MIT",
+			"optional": true
 		},
 		"node_modules/@types/unist": {
 			"version": "2.0.9",
@@ -1679,6 +1712,20 @@
 				"node": ">= 0.6"
 			}
 		},
+		"node_modules/core-js": {
+			"version": "3.50.0",
+			"resolved": "https://registry.npmjs.org/core-js/-/core-js-3.50.0.tgz",
+			"integrity": "sha512-BRWgOLKkFeCgRudR6zrs8p9XJZcE14grzKMMssoYrk6krtuEZ7MTKPIY5RzOnqsEKIR9kst7wNzphttraT+Yqw==",
+			"hasInstallScript": true,
+			"license": "MIT",
+			"engines": {
+				"node": "*"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/core-js"
+			}
+		},
 		"node_modules/cross-spawn": {
 			"version": "7.0.3",
 			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
@@ -1872,6 +1919,15 @@
 			},
 			"engines": {
 				"node": ">=6.0.0"
+			}
+		},
+		"node_modules/dompurify": {
+			"version": "3.4.15",
+			"resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.15.tgz",
+			"integrity": "sha512-EUBjM+B+lkDE41iE82DDSCfkoPGfXx8IxFxPMjNzm/Uk4xDet77rTN9wqlxlVg71kK7XGuUMv6wUxJUwwv+Xyw==",
+			"license": "(MPL-2.0 OR Apache-2.0)",
+			"optionalDependencies": {
+				"@types/trusted-types": "^2.0.7"
 			}
 		},
 		"node_modules/end-of-stream": {
@@ -3319,6 +3375,60 @@
 				"node": ">=4"
 			}
 		},
+		"node_modules/posthog-js": {
+			"version": "1.428.6",
+			"resolved": "https://registry.npmjs.org/posthog-js/-/posthog-js-1.428.6.tgz",
+			"integrity": "sha512-+sJ64F6nY37eaMr14GocpzeTHqohPKa6mAYS7dh+qegR7n+qu0u13+pc3Hu26YGQQA8dbjmTt12pEr05K3tZKw==",
+			"license": "(Apache-2.0 AND MIT)",
+			"dependencies": {
+				"@posthog/browser-common": "^0.8.2",
+				"@posthog/core": "^1.51.0",
+				"@posthog/types": "^1.409.2",
+				"core-js": "^3.49.0",
+				"dompurify": "^3.4.13",
+				"fflate": "^0.4.8",
+				"preact": "^10.29.3",
+				"query-selector-shadow-dom": "^1.0.1",
+				"web-vitals": "^6.2.1",
+				"web-vitals-soft-navs": "npm:web-vitals@6.2.1"
+			},
+			"peerDependencies": {
+				"@types/react": ">=16.8.0",
+				"react": ">=16.8.0"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				},
+				"react": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/posthog-js/node_modules/fflate": {
+			"version": "0.4.9",
+			"resolved": "https://registry.npmjs.org/fflate/-/fflate-0.4.9.tgz",
+			"integrity": "sha512-zdxgIEddhfsyCaWpJ2SdXEP8ZMrKJ6+5jl4OupODcywU0IhRk6gdXuVGcPICyfx2H97hVK7xmJtRLPjkxAX8Vw==",
+			"license": "MIT"
+		},
+		"node_modules/preact": {
+			"version": "10.29.8",
+			"resolved": "https://registry.npmjs.org/preact/-/preact-10.29.8.tgz",
+			"integrity": "sha512-ej2aVZ+vZ8WO7tvlQWRM9N63A0KzF9q4mWJfDUHgYaIofWY9hu74QdnQrjoPMmZi2/nZ5gN0bJCQF49xQqx09Q==",
+			"license": "MIT",
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/preact"
+			},
+			"peerDependencies": {
+				"preact-render-to-string": ">=5"
+			},
+			"peerDependenciesMeta": {
+				"preact-render-to-string": {
+					"optional": true
+				}
+			}
+		},
 		"node_modules/prebuild-install": {
 			"version": "7.1.1",
 			"resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.1.tgz",
@@ -3468,6 +3578,12 @@
 			"engines": {
 				"node": ">=6"
 			}
+		},
+		"node_modules/query-selector-shadow-dom": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/query-selector-shadow-dom/-/query-selector-shadow-dom-1.0.1.tgz",
+			"integrity": "sha512-lT5yCqEBgfoMYpf3F2xQRK7zEr1rhIIZuceDK6+xRkJQ4NMbHTwXqk4NkwDwQMNqXgG9r9fyHnzwNVs6zV5KRw==",
+			"license": "MIT"
 		},
 		"node_modules/queue-microtask": {
 			"version": "1.2.3",
@@ -4778,6 +4894,19 @@
 					"optional": true
 				}
 			}
+		},
+		"node_modules/web-vitals": {
+			"version": "6.2.1",
+			"resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-6.2.1.tgz",
+			"integrity": "sha512-rLcLXA2sx6+9dE88NHFubwTtGxpK4yYBLj6qHPdFoCaLr0cXGb4efOqtKLlm4loGA4OEKHIQKMKzZkKyOh5ctw==",
+			"license": "Apache-2.0"
+		},
+		"node_modules/web-vitals-soft-navs": {
+			"name": "web-vitals",
+			"version": "6.2.1",
+			"resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-6.2.1.tgz",
+			"integrity": "sha512-rLcLXA2sx6+9dE88NHFubwTtGxpK4yYBLj6qHPdFoCaLr0cXGb4efOqtKLlm4loGA4OEKHIQKMKzZkKyOh5ctw==",
+			"license": "Apache-2.0"
 		},
 		"node_modules/which": {
 			"version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
 		"@fontsource/nunito": "^5.3.0",
 		"@types/three": "^0.185.4",
 		"gsap": "^3.15.0",
+		"posthog-js": "^1.428.6",
 		"three": "^0.185.1"
 	}
 }

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -1,0 +1,173 @@
+import { browser } from '$app/environment';
+
+/**
+ * The site's whole surface onto PostHog.
+ *
+ * Shaped like the app's `lib/analytics.ts`, and for the same first reason: an
+ * optional service degrades rather than crashes. Without a key the SDK is
+ * never imported, no request leaves the browser, and every export here is a
+ * no-op — which is what a fork, a `npm run dev` and a preview build all get.
+ *
+ * Four settings below are declarations, not preferences. They are what
+ * `/cookie-policy` and `/privacy-policy` say about this site, and those pages
+ * are answered from this file; change one and the pages are wrong:
+ *
+ *  - `cookieless_mode: 'always'` — nothing is written to your browser. No
+ *    cookie, no localStorage, no sessionStorage. PostHog counts a visitor with
+ *    a hash it computes on its own side from a salt it discards daily, so
+ *    there is nothing stored on your device to ask consent for, and the site
+ *    keeps its promise of having no cookie banner.
+ *  - `person_profiles: 'never'` — no person record is created and `identify()`
+ *    is a no-op. This site has no accounts; identity lives in the app.
+ *  - `disable_session_recording: true` — no recordings, the same answer the app
+ *    gives.
+ *  - `autocapture: false` — clicks are not swept up wholesale. What is sent is
+ *    the page you are on plus the closed list of events in `SiteEvent` below,
+ *    which is the only reason a page like `/privacy-policy` can describe this
+ *    in a sentence rather than a paragraph of caveats.
+ *
+ * The cost of cookieless is real and worth stating rather than discovering: a
+ * returning visitor is a new one tomorrow. This measures which pages get read
+ * and which links get clicked, never retention.
+ *
+ * EU Cloud, because the users are — the same host the app defaults to, and as
+ * of September 2026 the same *project*: PostHog's free plan allows exactly one,
+ * so the site writes into the app's rather than a "LangX Web" of its own. That
+ * is why every event leaves here stamped with `langx_surface` — see
+ * `before_send` below. If the plan ever gains a second project, splitting them
+ * is a key change and a stamp that stops mattering, nothing more.
+ */
+
+const DEFAULT_HOST = 'https://eu.i.posthog.com';
+
+/**
+ * Vite inlines `VITE_*` at build time and leaves it `undefined` when unset,
+ * which is exactly the graceful-degradation this file needs. SvelteKit's
+ * `$env/static/public` is the more idiomatic import, but it is a build error
+ * rather than an `undefined` when the variable is missing, and a missing key
+ * has to stay a no-op here rather than break `npm run build` for anyone who
+ * clones this repository.
+ */
+const apiKey = (import.meta.env.VITE_POSTHOG_KEY as string | undefined) || null;
+const apiHost = (import.meta.env.VITE_POSTHOG_HOST as string | undefined) || DEFAULT_HOST;
+
+/**
+ * Every event this site is allowed to send, as a closed union — the same
+ * device the app uses to keep the list short and reviewable. Adding a member
+ * is a deliberate act that should come with a line in the privacy policy.
+ *
+ *  - `download_clicked` — a click on any link that leaves for the app: the
+ *    download page, the web app, or either store listing.
+ *  - `newsletter_subscribed` — the newsletter form came back ok. The address
+ *    itself is never a property; the API already has it.
+ */
+export type SiteEvent =
+	| { name: 'download_clicked'; properties: { destination: string; location: string } }
+	| { name: 'newsletter_subscribed'; properties?: never };
+
+/** The hosts a `download_clicked` is worth recording for. */
+const APP_HOSTS = ['get.langx.io', 'app.langx.io', 'apps.apple.com', 'play.google.com'];
+
+/**
+ * The package's default entry. The `dist/module.no-external.js` build was tried
+ * here, on the theory that compiling PostHog's extensions in would stop the SDK
+ * fetching anything from its asset CDN — it does exactly that on
+ * token.langx.io, which uses the `array.no-external` build. It made no
+ * difference from this entry point: the network log still shows the request to
+ * eu-assets.i.posthog.com. Not worth a fragile deep import into `dist/` for
+ * nothing, so this stays the plain import and section 3.4 of the cookie policy
+ * names that request rather than pretending it away.
+ */
+type PostHog = typeof import('posthog-js').default;
+
+let client: PostHog | null = null;
+let starting: Promise<void> | null = null;
+
+/**
+ * Starts the SDK and the one listener that feeds it.
+ *
+ * Called from the root layout's `load`, which runs at prerender time as well
+ * as in the browser — hence the `browser` guard rather than a check inside the
+ * caller, so there is one place that knows this must not run on the server.
+ */
+export function initAnalytics(): void {
+	if (!browser || !apiKey || starting) return;
+	starting = (async () => {
+		try {
+			const { default: posthog } = await import('posthog-js');
+			posthog.init(apiKey, {
+				api_host: apiHost,
+				// Pins the SDK's behaviour to a dated set of defaults rather than
+				// to whatever the latest version decides. This one turns
+				// `capture_pageview` into 'history_change', which is what makes
+				// SvelteKit's client-side navigations count as page views without
+				// a hook of our own.
+				defaults: '2026-05-30',
+				cookieless_mode: 'always',
+				person_profiles: 'never',
+				disable_session_recording: true,
+				autocapture: false,
+				// One project, two products. `$lib` ('web' here, 'posthog-react-native'
+				// in the app) would already tell them apart, but a dashboard filter
+				// should rest on a name we chose rather than on an SDK's internal
+				// detail. Stamped in `before_send` rather than `register()` because
+				// the first `$pageview` is captured during `init` and would miss a
+				// super property set on the line after it.
+				before_send: (event) => {
+					if (event) event.properties.langx_surface = 'website';
+					return event;
+				},
+				// Feature flags need a stable identity, which cookieless
+				// deliberately does not have, so nothing here could use one.
+				// Measured against an invalid key the SDK still called `/flags`
+				// once on load despite this; that may be a fallback for a remote
+				// config it could not fetch, and it was not worth a real key to
+				// find out. Treat the switch as intent, not as a promise about
+				// the request count.
+				advanced_disable_flags: true
+			});
+			client = posthog;
+			listenForAppLinks();
+		} catch {
+			// Blocked, offline, or a chunk that never arrived. The site does not
+			// depend on this and must not announce it.
+		}
+	})();
+}
+
+/** Sends one of the events named above. A no-op until the SDK is up. */
+export function track(event: SiteEvent): void {
+	client?.capture(event.name, event.properties);
+}
+
+/**
+ * One delegated listener instead of a handler on each of the ~15 "Start for
+ * free" buttons scattered across the marketing pages and the tools. Catches
+ * clicks that are routed through a child element too, which a per-button
+ * handler would also have to.
+ */
+function listenForAppLinks(): void {
+	document.addEventListener(
+		'click',
+		(event) => {
+			const target = event.target;
+			if (!(target instanceof Element)) return;
+			const link = target.closest('a');
+			if (!link?.href) return;
+			let host: string;
+			try {
+				host = new URL(link.href).host;
+			} catch {
+				return;
+			}
+			if (!APP_HOSTS.includes(host)) return;
+			track({
+				name: 'download_clicked',
+				properties: { destination: host, location: window.location.pathname }
+			});
+		},
+		// Capture phase: the click still counts if something downstream stops
+		// the event from bubbling.
+		{ capture: true }
+	);
+}

--- a/src/lib/components/molecules/NewsletterForm.svelte
+++ b/src/lib/components/molecules/NewsletterForm.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import Button from '$lib/components/atoms/Button.svelte';
+	import { track } from '$lib/analytics';
 
 	let email = '';
 	let state: 'idle' | 'sending' | 'ok' | 'error' = 'idle';
@@ -17,6 +18,9 @@
 			if (data.status === 'ok') {
 				email = '';
 				state = 'ok';
+				// The event carries no properties on purpose: the address went to
+				// our own API a line above and has no business going anywhere else.
+				track({ name: 'newsletter_subscribed' });
 			} else {
 				state = 'error';
 			}

--- a/src/lib/components/organisms/CookiePolicy.svelte
+++ b/src/lib/components/organisms/CookiePolicy.svelte
@@ -1,6 +1,6 @@
 <section id="policy">
 
-	*Effective Date: 27, Aug 2026*
+	*Effective Date: 8, Sep 2026*
 
 	1. Introduction
 
@@ -22,19 +22,23 @@
 
 		3.3 Analytics
 
-		**None on this site.** LangX version 1 ran a self-hosted analytics service on langx.io; it was retired and version 2 replaced it with nothing. This site sets no analytics cookie and counts no page views.
+		**This site has some now, and it stores nothing on your device to do it.** That is a change: until September 2026 this section said there were none at all, and the sentence you are reading replaced that one in the same release that switched them on.
 
-		The **app** is a different answer, and this section used to give the wrong one. It sends usage analytics to PostHog — screen names, a short list of events and your LangX user id, with no session recording and nothing that carries the content of a message. That is described in full in section 2.4 of the [privacy policy](/privacy-policy), and it is turned off in Settings → Privacy → Share usage data. It arrived without this page being updated first, which is not how it was supposed to go; the promise to say so beforehand stands for anything that comes next.
+		langx.io and token.langx.io send page views and a short list of events to **PostHog**, on its European cloud, in what PostHog calls cookieless mode. No cookie, no local storage, no session storage — nothing is written to your browser. A visitor is counted with a hash PostHog computes on its own side from a salt that is thrown away daily, so there is no identifier here that outlives a day. What is sent is the address of the page you are on, whether you clicked a link that leaves for the app, and whether a newsletter sign-up went through. There is no session recording, and clicks are not swept up wholesale — only the one just named.
+
+		The cost of that choice is worth stating rather than leaving you to work out: it cannot tell a returning reader from a new one, so it measures what gets read and never who reads it.
+
+		The **app** is a separate answer with a separate switch. It sends screen names, a short list of events and your LangX user id, described in full in section 2.4 of the [privacy policy](/privacy-policy) and turned off in Settings → Privacy → Share usage data. When that arrived, this page was not updated first, and we said the promise to say so beforehand would stand for anything that came next. This was that next thing.
 
 		3.4 Third-party cookies
 
-		**We do not use any.** There is no Google Analytics, no advertising network, and no social media tracking pixel on this site. Fonts and scripts are served from langx.io itself rather than from a third-party CDN.
+		**We do not use any.** There is no Google Analytics, no advertising network, and no social media tracking pixel on this site, and the analytics in section 3.3 sets no cookie of any kind. PostHog's script is served from langx.io itself rather than from its CDN, the way our fonts are.
 
-		One thing is worth naming rather than hiding behind that sentence: the star count in our header is read from GitHub's public API by your browser, so GitHub sees the request the way it sees any visit to a page. It sets no cookie and we send it nothing about you.
+		Two things are worth naming rather than hiding behind that sentence. The star count in our header is read from GitHub's public API by your browser, so GitHub sees the request the way it sees any visit to a page. And serving PostHog's script ourselves does not mean your browser never talks to PostHog: the SDK fetches a small configuration file from its asset host, and the events themselves go to its European endpoint, so both of those connections are made from your browser directly. Neither GitHub nor PostHog sets a cookie, and neither is told anything about you beyond what is described above.
 
 	4. Your Consent
 
-		The only things stored on your device are the ones described above: what is needed to keep you signed in, and preferences you set yourself. Nothing here tracks you, which is why this site has no cookie banner — there is nothing to ask you to consent to. You can clear what is stored at any time through your browser settings, though clearing the essential ones will sign you out.
+		The only things stored on your device are the ones described above: what is needed to keep you signed in, and preferences you set yourself. The analytics in section 3.3 adds nothing to that list, because it writes nothing at all — which is why this site still has no cookie banner. There is genuinely nothing stored on your device for us to ask you to consent to. You can clear what is stored at any time through your browser settings, though clearing the essential ones will sign you out.
 
 	5. How to Manage Cookies
 

--- a/src/lib/components/organisms/OpenSource.svelte
+++ b/src/lib/components/organisms/OpenSource.svelte
@@ -9,8 +9,9 @@
 	 * the licence file, the repository, the self-hosting guide.
 	 *
 	 * Deliberately says nothing about tracking or analytics. The app ships a
-	 * product-analytics SDK, so a "no trackers" line here would be false — see
-	 * the note in PRODUCT.md.
+	 * product-analytics SDK and this site now sends cookieless page views to the
+	 * same one, so a "no trackers" line here would be false — see the note in
+	 * PRODUCT.md and `$lib/analytics`.
 	 */
 	const repo = 'langx/langx';
 	let stars = -1;

--- a/src/lib/components/organisms/PrivacyPolicy.svelte
+++ b/src/lib/components/organisms/PrivacyPolicy.svelte
@@ -1,6 +1,6 @@
 <section id="policy">
 
-	*Effective Date: 3, Sep 2026*
+	*Effective Date: 8, Sep 2026*
 
 	1. Introduction
 
@@ -58,7 +58,9 @@
 		- **No location from analytics.** PostHog is told not to turn the connection's IP address into a country, so analytics adds nothing to what section 3 describes.
 		- **The identifier is ours.** You are identified by your LangX user id and nothing else — no email address, no name. That is also what lets a deleted account's events be found and deleted with it.
 
-		It is on by default and it is optional: **Settings → Privacy → Share usage data** turns it off, and a refusal made before signing in is honoured. There is no analytics on this website — no page-view counter, no analytics cookie, nothing.
+		It is on by default and it is optional: **Settings → Privacy → Share usage data** turns it off, and a refusal made before signing in is honoured.
+
+		**The website is a second, smaller answer.** Until September 2026 the line here said langx.io had no analytics at all; it now has some, and this paragraph went in with the change rather than after it. langx.io and token.langx.io send page views, a click on a link that leaves for the app, and a completed newsletter sign-up to the same PostHog, on the same European cloud — in cookieless mode, which writes no cookie and no browser storage whatsoever and counts a visitor with a hash PostHog derives from a daily salt it then discards. There is no account to attach it to and no attempt to make one: no person record is created, nothing is identified, and a visitor today cannot be recognised as the same one tomorrow. That is a deliberate limit and not an oversight. The [cookie policy](/cookie-policy) describes it in section 3.3.
 
 	3. Approximate Location, and Only If You Ask For It
 
@@ -75,7 +77,7 @@
 		Stating this precisely is what makes the rest of the policy credible.
 
 		- **No precise location.** See section 3: the app asks for the coarsest reading your device will give and rounds it before storing it. A street-level position is never collected.
-		- **No session recording, and no analytics on this website.** The app does send usage analytics — section 2.4 says exactly what, and how to turn it off — but nothing records your screen, and langx.io itself has no analytics of any kind: no page-view counter, no analytics cookie.
+		- **No session recording, anywhere.** The app and the website both send usage analytics — section 2.4 says exactly what, and how to turn the app's off — but nothing records your screen, and the website's analytics writes no cookie and no browser storage at all.
 		- **No advertising identifiers.** No IDFA, no Android advertising ID, no ad network, and nothing is sold or passed to a data broker.
 		- **No tracking across other apps or websites.**
 		- **No contacts, no calendar, no photos beyond the ones you choose to upload, no microphone access outside recording a voice message you send, no health data.**
@@ -101,7 +103,7 @@
 		- **Expo's push service**, and through it Apple's and Google's push infrastructure — your push token and the text of the notification. A new-message notification includes the beginning of the message, because that is what makes it useful; if you would rather it did not, turn notifications off.
 		- **Cloudflare R2 or Backblaze B2**, our object storage — your photos, videos and voice messages, to host them.
 		- **Sentry**, our error reporting service — the details of a server error, with your user id attached so we can tell whether a fault affected one account or everybody. It is configured never to send request bodies, cookies or authentication headers, so message contents and session tokens do not reach it.
-		- **PostHog**, our analytics provider, on its European cloud — the screen names, events and user id described in section 2.4. It processes them for us and for nothing of its own, and you can switch this off in Settings.
+		- **PostHog**, our analytics provider, on its European cloud — the screen names, events and user id described in section 2.4, and from the website the page views and two events described in the same section. It processes them for us and for nothing of its own, and you can switch the app's off in Settings.
 		- **Google and Apple**, if you choose to sign in with them — they tell us your email address and name; we tell them nothing about what you do in LangX.
 
 		Our servers run on **Fly.io** in Frankfurt, our database is **MongoDB Atlas**, and langx.io is served through **Cloudflare**. These providers host and deliver the service and do not use your data for any purpose of their own.

--- a/src/routes/+layout.ts
+++ b/src/routes/+layout.ts
@@ -1,3 +1,12 @@
+import { initAnalytics } from '$lib/analytics';
+
 // since there's no dynamic data here, we can prerender
 // it so that it gets served as a static asset in production
 export const prerender = true;
+
+// The root load is the earliest place that runs in the browser on every page,
+// which is where PostHog's own SvelteKit guide puts `init`. It is a no-op
+// during prerendering and a no-op without a key; see `$lib/analytics`.
+export const load = () => {
+	initAnalytics();
+};


### PR DESCRIPTION
langx.io has had no analytics since v1's self-hosted Plausible was retired. This adds PostHog, on the same EU cloud and now the same **project** as the app — PostHog's free plan allows exactly one, so a separate "LangX Web" would have needed a card.

## Why this is a small change

It runs in **cookieless mode**. Nothing is written to the visitor's browser — no cookie, no localStorage, no sessionStorage. PostHog counts a visitor with a hash it derives on its own side from a salt it discards daily, which is why section 4 of the cookie policy still holds and the site still has no banner to show.

Measured in a browser against a live build, not assumed:

| | Result |
|---|---|
| Cookies / localStorage / sessionStorage / IndexedDB | all empty |
| Events | reach `eu.i.posthog.com/e/` |
| `langx_surface` on the payload | present (verified via `capture()`'s return) |
| With no key | zero external requests; the 285K chunk is never fetched |

## What is sent

The page, a click on any link that leaves for the app, and a completed newsletter sign-up. Autocapture is **off**, so it is that list and nothing else — which is what lets the policy describe this in a paragraph instead of a page of caveats. The newsletter event carries no properties; the address went to our own API and has no business going anywhere else.

Every event carries `langx_surface: 'website'`, stamped in `before_send` rather than `register()` because the first `$pageview` is captured during `init` and would miss a super property set on the line after it. **The app's dashboards need a filter on this** now that both write to one project, or web page views will land in app metrics.

## The cost, stated rather than buried

Without a stable identity there is no retention, no funnel across days, and a returning reader is a new one tomorrow. That was the trade for keeping the banner off.

## Two things reviewers should look at

1. **The policy pages change in this same commit, deliberately.** When the app got analytics the cookie page was updated afterwards, and it carries an explicit promise that the next time would come with the notice rather than after it. This is that next time. Cookie policy §3.3/§3.4/§4 and privacy policy §2.4/§4/§6 are rewritten; both effective dates move to 8 Sep 2026.
2. **§3.4 names two connections rather than pretending them away.** PostHog's script is bundled and served from langx.io, but the SDK still fetches a small config file from `eu-assets.i.posthog.com` and sends events to its EU endpoint. I tried the `no-external` build to remove the first — it works on token.langx.io's `array.*` build but made no difference from this `module.*` entry point, so I reverted the fragile deep import and the policy names the request instead.

`advanced_disable_flags: true` also did not remove the `/flags` call when measured against an invalid key; the code comment says so rather than claiming otherwise.

## Not covered

`docs.langx.io` is GitBook and cannot be instrumented from its repo. Its official PostHog integration injects the standard script, which would set cookies and need a banner — so the policy text names only langx.io and token.langx.io.

## Config

`VITE_POSTHOG_KEY` is set as a repository **variable**, not a secret: Vite inlines it into the bundle every visitor downloads, so calling it a secret would only be theatre. A PostHog project key can write events and never read them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)