### PR TITLE
Start analytics on mount, because a prerendered page never re-runs load

### DIFF
--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -69,14 +69,13 @@ export type SiteEvent =
 const APP_HOSTS = ['get.langx.io', 'app.langx.io', 'apps.apple.com', 'play.google.com'];
 
 /**
- * The package's default entry. The `dist/module.no-external.js` build was tried
- * here, on the theory that compiling PostHog's extensions in would stop the SDK
- * fetching anything from its asset CDN — it does exactly that on
- * token.langx.io, which uses the `array.no-external` build. It made no
- * difference from this entry point: the network log still shows the request to
- * eu-assets.i.posthog.com. Not worth a fragile deep import into `dist/` for
- * nothing, so this stays the plain import and section 3.4 of the cookie policy
- * names that request rather than pretending it away.
+ * The package's default entry. `dist/module.no-external.js` was tried here, on
+ * the theory that compiling PostHog's extensions in would stop the SDK fetching
+ * anything from its asset CDN, and made no difference — but measured against
+ * the built, prerendered output the default entry makes no asset-CDN or /flags
+ * request either. The earlier observation of both came from `vite preview`, so
+ * treat request counts as something to re-measure on a real build rather than
+ * to assume from a dev server.
  */
 type PostHog = typeof import('posthog-js').default;
 
@@ -86,9 +85,11 @@ let starting: Promise<void> | null = null;
 /**
  * Starts the SDK and the one listener that feeds it.
  *
- * Called from the root layout's `load`, which runs at prerender time as well
- * as in the browser — hence the `browser` guard rather than a check inside the
- * caller, so there is one place that knows this must not run on the server.
+ * Called from the root layout's `onMount`, not its `load`: every page here is
+ * prerendered, and SvelteKit hydrates a prerendered page from serialised data
+ * rather than re-running the universal `load`, so `load` never fired on a visit
+ * arriving from outside. The `browser` guard stays anyway — it costs nothing
+ * and keeps the rule in one place rather than in the caller.
  */
 export function initAnalytics(): void {
 	if (!browser || !apiKey || starting) return;

--- a/src/lib/components/organisms/CookiePolicy.svelte
+++ b/src/lib/components/organisms/CookiePolicy.svelte
@@ -34,7 +34,7 @@
 
 		**We do not use any.** There is no Google Analytics, no advertising network, and no social media tracking pixel on this site, and the analytics in section 3.3 sets no cookie of any kind. PostHog's script is served from langx.io itself rather than from its CDN, the way our fonts are.
 
-		Two things are worth naming rather than hiding behind that sentence. The star count in our header is read from GitHub's public API by your browser, so GitHub sees the request the way it sees any visit to a page. And serving PostHog's script ourselves does not mean your browser never talks to PostHog: the SDK fetches a small configuration file from its asset host, and the events themselves go to its European endpoint, so both of those connections are made from your browser directly. Neither GitHub nor PostHog sets a cookie, and neither is told anything about you beyond what is described above.
+		Two things are worth naming rather than hiding behind that sentence. The star count in our header is read from GitHub's public API by your browser, so GitHub sees the request the way it sees any visit to a page. And serving PostHog's script ourselves does not mean your browser never talks to PostHog: the page views go to its European endpoint, and that connection is made from your browser directly rather than through us. Neither GitHub nor PostHog sets a cookie, and neither is told anything about you beyond what is described above.
 
 	4. Your Consent
 

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -1,5 +1,23 @@
-<script>
+<script lang="ts">
+	import { onMount } from 'svelte';
+	import { initAnalytics } from '$lib/analytics';
 	import '$lib/scss/global.scss';
+
+	/**
+	 * Analytics starts here rather than in `+layout.ts`, which is where
+	 * PostHog's own SvelteKit guide puts it. That guide assumes a page rendered
+	 * per request; every page of this site is prerendered by adapter-static, and
+	 * on the first load of a prerendered page SvelteKit hydrates from the
+	 * serialised layout data instead of re-running the universal `load`. It only
+	 * re-runs on a later client-side navigation, so `load` fired on an internal
+	 * link and never on the visit that arrived from outside — which is most of
+	 * them.
+	 *
+	 * Caught in production rather than in review: the deployed bundle carried
+	 * the key and the config, and the PostHog chunk was still never fetched.
+	 * `onMount` runs on hydration, always, which is what this needs.
+	 */
+	onMount(initAnalytics);
 </script>
 
 <slot />

--- a/src/routes/+layout.ts
+++ b/src/routes/+layout.ts
@@ -1,12 +1,3 @@
-import { initAnalytics } from '$lib/analytics';
-
 // since there's no dynamic data here, we can prerender
 // it so that it gets served as a static asset in production
 export const prerender = true;
-
-// The root load is the earliest place that runs in the browser on every page,
-// which is where PostHog's own SvelteKit guide puts `init`. It is a no-op
-// during prerendering and a no-op without a key; see `$lib/analytics`.
-export const load = () => {
-	initAnalytics();
-};


### PR DESCRIPTION
Follow-up to #161, which shipped analytics that never ran.

## The bug

`initAnalytics()` went in the root `+layout.ts` `load`, which is where [PostHog's SvelteKit guide](https://posthog.com/docs/libraries/svelte) puts it. That guide assumes a page rendered per request. Every page here is prerendered by `adapter-static`, and SvelteKit hydrates a prerendered page from the **serialised layout data** rather than re-running the universal `load`. So `load` fired on an internal client-side navigation and never on a visit arriving from outside — which is most of them.

It looked fine in local testing because `vite preview` reached it through a navigation. On langx.io the deployed bundle carried the key and the whole config, and the PostHog chunk was still never fetched. Not a single page view was counted.

`onMount` runs on hydration, always.

## Verified properly this time

Against the **built, prerendered output** served as static files and entered cold from outside — the shape that actually ships, not a dev server:

| | Before | After |
|---|---|---|
| PostHog chunk fetched on a cold first load | no | **yes** |
| Events reach `eu.i.posthog.com/e/` | no | **yes** |
| Cookies / localStorage / sessionStorage | empty | **empty** |

(The initial `$pageview` is batched — it flushes on a later capture or on page hide, so it does not appear in the network log in the first few seconds. That is PostHog's normal behaviour, not a second bug.)

## It also corrects the cookie policy

Section 3.4 said the SDK fetches a small configuration file from PostHog's asset host. That is what `vite preview` showed; the real build makes **no** asset-CDN request and **no** `/flags` call. The section now names the one connection that does happen — page views to PostHog's EU endpoint — rather than one that does not. The note in `analytics.ts` says to re-measure request counts on a real build rather than trust a dev server.

## Separately, and not fixed here

`static.cloudflareinsights.com` is loading on langx.io — Cloudflare Web Analytics, injected by Cloudflare Pages, not by this repo. It predates these PRs, but cookie policy §3.4 currently implies nothing third-party is measuring the site. It is either worth turning off in the Cloudflare dashboard or worth naming in §3.4; that is a decision rather than a fix, so it is not in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)