### PR TITLE
Name the Cloudflare analytics that was already there

### DIFF
--- a/src/lib/components/organisms/CookiePolicy.svelte
+++ b/src/lib/components/organisms/CookiePolicy.svelte
@@ -22,23 +22,25 @@
 
 		3.3 Analytics
 
-		**This site has some now, and it stores nothing on your device to do it.** That is a change: until September 2026 this section said there were none at all, and the sentence you are reading replaced that one in the same release that switched them on.
+		**This site has analytics, and none of it is stored on your device.** That is a change: until September 2026 this section said there were none at all. There are two, and both are described below.
 
 		langx.io and token.langx.io send page views and a short list of events to **PostHog**, on its European cloud, in what PostHog calls cookieless mode. No cookie, no local storage, no session storage — nothing is written to your browser. A visitor is counted with a hash PostHog computes on its own side from a salt that is thrown away daily, so there is no identifier here that outlives a day. What is sent is the address of the page you are on, whether you clicked a link that leaves for the app, and whether a newsletter sign-up went through. There is no session recording, and clicks are not swept up wholesale — only the one just named.
 
 		The cost of that choice is worth stating rather than leaving you to work out: it cannot tell a returning reader from a new one, so it measures what gets read and never who reads it.
 
+		There is a second one, thinner, and it predates the first. Both sites are served through Cloudflare, and Cloudflare Pages measures the traffic it delivers: the page, the link that referred you, your country, and which browser, operating system and device type asked. It is switched on in Cloudflare's dashboard rather than by anything in our code, which is how it went unnamed here for longer than it should have. It writes nothing to your browser either — we opened the site and checked rather than taking the word for it — so section 4 is unchanged by it.
+
 		The **app** is a separate answer with a separate switch. It sends screen names, a short list of events and your LangX user id, described in full in section 2.4 of the [privacy policy](/privacy-policy) and turned off in Settings → Privacy → Share usage data. When that arrived, this page was not updated first, and we said the promise to say so beforehand would stand for anything that came next. This was that next thing.
 
 		3.4 Third-party cookies
 
-		**We do not use any.** There is no Google Analytics, no advertising network, and no social media tracking pixel on this site, and the analytics in section 3.3 sets no cookie of any kind. PostHog's script is served from langx.io itself rather than from its CDN, the way our fonts are.
+		**We do not use any.** There is no Google Analytics, no advertising network, and no social media tracking pixel on this site, and neither of the two analytics in section 3.3 sets a cookie of any kind. PostHog's script is served from langx.io itself rather than from its CDN, the way our fonts are; Cloudflare's is the exception, and it is named below.
 
-		Two things are worth naming rather than hiding behind that sentence. The star count in our header is read from GitHub's public API by your browser, so GitHub sees the request the way it sees any visit to a page. And serving PostHog's script ourselves does not mean your browser never talks to PostHog: the page views go to its European endpoint, and that connection is made from your browser directly rather than through us. Neither GitHub nor PostHog sets a cookie, and neither is told anything about you beyond what is described above.
+		Three things are worth naming rather than hiding behind that sentence. The star count in our header is read from GitHub's public API by your browser, so GitHub sees the request the way it sees any visit to a page. Serving PostHog's script ourselves does not mean your browser never talks to PostHog: the page views go to its European endpoint, and that connection is made from your browser directly rather than through us. And Cloudflare, which serves this site, adds a small measurement script of its own from its own domain — the one described in section 3.3, injected at its edge rather than written into our pages. None of the three sets a cookie, and none is told anything about you beyond what is described above.
 
 	4. Your Consent
 
-		The only things stored on your device are the ones described above: what is needed to keep you signed in, and preferences you set yourself. The analytics in section 3.3 adds nothing to that list, because it writes nothing at all — which is why this site still has no cookie banner. There is genuinely nothing stored on your device for us to ask you to consent to. You can clear what is stored at any time through your browser settings, though clearing the essential ones will sign you out.
+		The only things stored on your device are the ones described above: what is needed to keep you signed in, and preferences you set yourself. Neither of the analytics in section 3.3 adds anything to that list, because neither writes anything at all — which is why this site still has no cookie banner. There is genuinely nothing stored on your device for us to ask you to consent to. You can clear what is stored at any time through your browser settings, though clearing the essential ones will sign you out.
 
 	5. How to Manage Cookies
 

--- a/src/lib/components/organisms/PrivacyPolicy.svelte
+++ b/src/lib/components/organisms/PrivacyPolicy.svelte
@@ -60,7 +60,9 @@
 
 		It is on by default and it is optional: **Settings → Privacy → Share usage data** turns it off, and a refusal made before signing in is honoured.
 
-		**The website is a second, smaller answer.** Until September 2026 the line here said langx.io had no analytics at all; it now has some, and this paragraph went in with the change rather than after it. langx.io and token.langx.io send page views, a click on a link that leaves for the app, and a completed newsletter sign-up to the same PostHog, on the same European cloud — in cookieless mode, which writes no cookie and no browser storage whatsoever and counts a visitor with a hash PostHog derives from a daily salt it then discards. There is no account to attach it to and no attempt to make one: no person record is created, nothing is identified, and a visitor today cannot be recognised as the same one tomorrow. That is a deliberate limit and not an oversight. The [cookie policy](/cookie-policy) describes it in section 3.3.
+		**The website is a second, smaller answer.** Until September 2026 the line here said langx.io had no analytics at all; it now has some, and this paragraph went in with the change rather than after it. langx.io and token.langx.io send page views, a click on a link that leaves for the app, and a completed newsletter sign-up to the same PostHog, on the same European cloud — in cookieless mode, which writes no cookie and no browser storage whatsoever and counts a visitor with a hash PostHog derives from a daily salt it then discards. There is no account to attach it to and no attempt to make one: no person record is created, nothing is identified, and a visitor today cannot be recognised as the same one tomorrow. That is a deliberate limit and not an oversight.
+
+		**Cloudflare measures the same two sites**, separately and more thinly, because it serves them: the page, the referring link, your country, and which browser, operating system and device type asked. It is switched on in Cloudflare's dashboard rather than by anything in our code, and it writes nothing to your browser either. The [cookie policy](/cookie-policy) describes both in section 3.3.
 
 	3. Approximate Location, and Only If You Ask For It
 
@@ -77,7 +79,7 @@
 		Stating this precisely is what makes the rest of the policy credible.
 
 		- **No precise location.** See section 3: the app asks for the coarsest reading your device will give and rounds it before storing it. A street-level position is never collected.
-		- **No session recording, anywhere.** The app and the website both send usage analytics — section 2.4 says exactly what, and how to turn the app's off — but nothing records your screen, and the website's analytics writes no cookie and no browser storage at all.
+		- **No session recording, anywhere.** The app and the website both send usage analytics — section 2.4 says exactly what, and how to turn the app's off — but nothing records your screen, and neither of the website's two writes a cookie or any browser storage at all.
 		- **No advertising identifiers.** No IDFA, no Android advertising ID, no ad network, and nothing is sold or passed to a data broker.
 		- **No tracking across other apps or websites.**
 		- **No contacts, no calendar, no photos beyond the ones you choose to upload, no microphone access outside recording a voice message you send, no health data.**
@@ -106,7 +108,7 @@
 		- **PostHog**, our analytics provider, on its European cloud — the screen names, events and user id described in section 2.4, and from the website the page views and two events described in the same section. It processes them for us and for nothing of its own, and you can switch the app's off in Settings.
 		- **Google and Apple**, if you choose to sign in with them — they tell us your email address and name; we tell them nothing about what you do in LangX.
 
-		Our servers run on **Fly.io** in Frankfurt, our database is **MongoDB Atlas**, and langx.io is served through **Cloudflare**. These providers host and deliver the service and do not use your data for any purpose of their own.
+		Our servers run on **Fly.io** in Frankfurt, our database is **MongoDB Atlas**, and langx.io is served through **Cloudflare**, which also measures the traffic it delivers as described in section 2.4. These providers host and deliver the service and do not use your data for any purpose of their own.
 
 		We may also disclose information where we are legally required to do so.
 


### PR DESCRIPTION
Both sites load `https://static.cloudflareinsights.com/beacon.min.js/...` — Cloudflare Web Analytics, switched on in the Cloudflare dashboard rather than by anything in this repository, and predating the PostHog work by some time. Nothing here put it there and nothing here removes it. But cookie policy §3.4 said **two** things were worth naming and this was neither, which made the section wrong the moment you opened the network tab.

## What changed

- **§3.3** — says there are two analytics rather than one, and describes what Cloudflare collects: the page, the referring link, the country, and the browser, operating system and device type.
- **§3.4** — three third-party connections instead of two, and says plainly that Cloudflare's script is the one exception to "scripts are served from langx.io itself".
- **§4** — unchanged in substance, because the answer does not change: it writes nothing to the browser, so there is still nothing to consent to and still no banner.
- **Privacy policy** — a paragraph in §2.4, the "nothing records your screen" bullet in §4 widened to cover both, and §6 noting that the Cloudflare already listed as our host also measures the traffic it delivers.

## Sourcing

The storage claim is **measured, not taken on faith**: langx.io was opened and `document.cookie`, `localStorage` and `sessionStorage` all came back empty apart from SvelteKit's own scroll/snapshot keys. The list of collected fields is from [Cloudflare's dimensions documentation](https://developers.cloudflare.com/web-analytics/data-metrics/dimensions/).

I deliberately did **not** write that it is "GDPR compliant" or "needs no banner" — Cloudflare's own FAQ and overview pages do not state the cookie/storage position in terms I could quote, so the text sticks to what was observed and what the dimensions page lists.

## The alternative, not taken

Turning it off in the Cloudflare dashboard would have made the pages accurate as they were, and PostHog now covers the same ground. That was offered and naming it was chosen instead; it stays on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)